### PR TITLE
Text edits

### DIFF
--- a/app/scripts/components/Create/index.jsx
+++ b/app/scripts/components/Create/index.jsx
@@ -15,12 +15,11 @@ function Create() {
       <article className="c-article">
         <div className="row align-center">
           <div className="column small-12 medium-8">
-            <h2>Find, collect and share climate-relevant data from different sources in one place.
+            <h2>Find, collect and share climate-relevant data from different sources in one place
             </h2>
-            <p>The next phase of the PREP platform will enable users to <Link
-              to="create">create</Link> personalized dashboards of climate risks that combine
+            <p>The next phase of the PREP platform will enable users to create personalized dashboards of climate risks that combine
               top-down data with local information. Upload your own data or pull in data from
-              authoritative global sources, build a Dashboard of indicators and interactive
+              authoritative global sources, build a dashboard of indicators and interactive
               data-driven stories, and share with or learn from peers others.
             </p>
             <p>The customization feature is currently under development, see how it will work.
@@ -63,10 +62,10 @@ function Create() {
             <div className="column align-middle small-12 medium-6">
               <h3>Create Personalized Dashboards</h3>
               <p>Collect data, tools and insights relevant to you and your community in one place.
-                Create and share your own online Dashboard containing data, information, tools,
+                Create and share your own online dashboard containing data, information, tools,
                 interactive stories and other dynamic resources specific to your own geographic or
-                topical area of interest. Look at what data, tools, and insights others are using,
-                get regular updates and add them to your dashboard.
+                topical area of interest. Look at what data, tools, and insights others are using
+                and add them to your dashboard. Get updates when datasets are added.
               </p>
               <Link to="/dashboards"> See dashboards </Link>
             </div>
@@ -78,7 +77,7 @@ function Create() {
             <div className="column align-middle small-12 medium-6">
               <h3>Share Insights</h3>
               <p>Choose from a range of open source tools to share an insight about your data and
-                how it can or is being used to inform and manage climate risk. Embed your Dashboard
+                how it can or is being used to inform and manage climate risk. Embed your dashboard
                 or insights on your own website and share them with your community.
               </p>
               <Link to="/insights"> See insights </Link>
@@ -94,7 +93,7 @@ function Create() {
       <article className="c-article">
         <div className="row align-center">
           <div className="column small-12 medium-8">
-            <h2>Become a Pilot User</h2>
+            <h2>Become a pilot user</h2>
             <p>Would you like to develop a dashboard? Or share insights from your community? Over
               the coming months we plan to work with communities around the globe to help them
               develop their own dashboards.</p>

--- a/app/scripts/components/Dashboards/DashboardDetail.jsx
+++ b/app/scripts/components/Dashboards/DashboardDetail.jsx
@@ -87,8 +87,8 @@ class DashboardDetail extends React.Component {
           dashboardSlug={this.props.dashboardSlug}
           currentSection="dashboards"
         >
-          <p>This is an initial list of insights, data and tools that are important for our work</p>
           <p dangerouslySetInnerHTML={{__html:this.props.data.summary }}></p>
+          <p>This is an initial list of insights, data and tools that are important for our work.</p>
         </SectionIntro>
 
         <NavTab

--- a/app/scripts/components/Dashboards/index.jsx
+++ b/app/scripts/components/Dashboards/index.jsx
@@ -77,9 +77,9 @@ class DashboardsPage extends React.Component {
           <div className="row align-center">
             <div className="column small-12 medium-8">
               <h2>Find collections of climate risk data, insights, and tools contributed by partner
-                communities.
+                communities
               </h2>
-              <p>This is a list of initial dashboards for the beta version of this platform.</p>
+              <p>This is a list of initial dashboards for the beta version of the PREP Platform. In PREP’s next phase, any user will be able to <Link to="/create">create</Link> and share their own dashboards and insights.</p>
             </div>
           </div>
         </article>

--- a/app/scripts/components/Explore/ExploreSidebar.jsx
+++ b/app/scripts/components/Explore/ExploreSidebar.jsx
@@ -60,7 +60,7 @@ class DataMap extends React.Component {
             subtitle = metadata.subtitle;
           }
           if (metadata.organization) {
-            partner = <span>from <strong>{metadata.organization}</strong></span>;
+            partner = <span><br/>Source: <strong>{metadata.organization}</strong></span>;
           }
         }
       }

--- a/app/scripts/components/Explore/MetadataList.jsx
+++ b/app/scripts/components/Explore/MetadataList.jsx
@@ -76,7 +76,7 @@ function MetadataInfo(props) {
       }
       {metadataInfo.attributes.source &&
         <li>
-          <span>Source: </span>
+          <span>Access: </span>
           <span>
             <a href={metadataInfo.attributes.source} target="_blank">
               {metadataInfo.attributes.source}

--- a/app/scripts/components/FAQ/index.jsx
+++ b/app/scripts/components/FAQ/index.jsx
@@ -57,12 +57,10 @@ class FAQ extends React.Component {
             climate resilience.
           </p>
           <p>You can find additional information about climate projections on <a
-            href="https://www.climate.gov/maps-data/primer/predicting-climate" target="_blank">Climate.gov</a>
-            and in the <a
+            href="https://www.climate.gov/maps-data/primer/predicting-climate" target="_blank">Climate.gov</a> and in the <a
               href="http://nca2014.globalchange.gov/report/appendices/climate-science-supplement#statement-38714"
               target="_blank">U.S. National Climate Assessment</a>. You can also find a list of
-            climate resilience tools and services on the <Link to="/resources">Resources</Link>
-            page.
+            climate resilience tools and services on the <Link to="/resources">Resources</Link> page.
           </p>
 
           <h3>How can I get involved?</h3>
@@ -70,26 +68,29 @@ class FAQ extends React.Component {
             href="mailto:info@prepdata.org">info@prepdata.org</a> or fill out this <Link
             to='/contact'>form</Link>.
           </p>
-          <p>If you would like to join PREP, prepare a short letter of intent expressing your
+          <p>If you would like to <Link to="/about">join</Link> PREP, prepare a short letter of intent expressing your
             entity’s interest in PREP, your intended workgroup, and how you meet the partner
-            criteria. Learn more <Link to="/about">here</Link>.
+            criteria.
           </p>
 
           <h3>Who do I contact about media inquiries?</h3>
           <p>Please contact us at <a href="mailto:info@prepdata.org">info@prepdata.org</a> “Media
             Inquiry” in the subject line.
           </p>
+
+          <h3>What is coming next for PREP?</h3>
+          <p>The next phase of the PREP platform will enable users to create personalized dashboards of climate risks that combine top-down data with local information. To learn more about this feature or to apply to be a pilot user, see the <Link to='/create'>Create</Link> page.
+          </p>
         </Article>
         <Article>
           <h2>The PREP Platfrom</h2>
           <h3>How do I find data in PREP?</h3>
-          <p>All data on the PREP platform can be found in the <Link to="/explore">Explore</Link>
-            section. You can also find a list of climate-related data portals or the <Link
+          <p>All data on the PREP platform can be found in the <Link to="/explore">Explore</Link> section. You can also find a list of climate-related data portals or the <Link
               to="/resources">Resources</Link> page.
           </p>
 
           <h3>What if I have difficulty downloading data?</h3>
-          <p>Please let us know! <Link to="/contact">contact us</Link> at info@prepdata.org with the
+          <p>Please let us know! <Link to="/contact">Contact us</Link> at info@prepdata.org with the
             name of the dataset and a description of your issue.
           </p>
 
@@ -109,10 +110,9 @@ class FAQ extends React.Component {
 
           <h3>How do I create a dashboard or insight in PREP?</h3>
           <p>The ability to create and customize dashboards and insights is currently under
-            development. To learn more about this feature or to apply to be a pilot user, see the
-            <Link to='/create'>Create</Link> page.
+            development. To learn more about this feature or to apply to be a pilot user, see the <Link to='/create'>Create</Link> page.
           </p>
-          <p>If you are interested in data storytelling, we also recommend trying Esri <a
+          <p>If you are interested in data storytelling, you may wish to try Esri <a
             href="https://storymaps.arcgis.com/en/" target="_blank">Story Maps</a>.</p>
 
           <h3>Which web browser should I use to explore this site?</h3>
@@ -127,9 +127,8 @@ class FAQ extends React.Component {
           </p>
 
           <h3>I see an error or have a suggestion for the site. Where do I report it?</h3>
-          <p>We are eager for feedback and suggestions. Please <Link to="/contact">contact us</Link>
-            at info@prepdata.org.</p>
-
+          <p>We are eager for feedback and suggestions. Please <Link to="/contact">contact us</Link> at info@prepdata.org.
+          </p>
         </Article>
       </div>
     );

--- a/app/scripts/components/Home/index.jsx
+++ b/app/scripts/components/Home/index.jsx
@@ -24,10 +24,10 @@ class Home extends React.Component {
               <p>We promote collaboration among data and information producers and users.</p>
 
               <h3>Data</h3>
-              <p>We will seek to reduce the barriers to accessing, contributing, and using data for climate resilience.</p>
+              <p>We seek to reduce the barriers to accessing, contributing, and using data for climate resilience.</p>
 
               <h3>Platforms</h3>
-              <p>We will develop platforms to enhance access to and usability of climate-relevant data and information.</p>
+              <p>We develop platforms to enhance access to and usability of climate-relevant data and information.</p>
 
               <Link to="/about">Learn more</Link>
               </div>
@@ -38,7 +38,7 @@ class Home extends React.Component {
             <Article grid="small-12" no-border floating>
               <img src={ladyInLand} />
               <div className="padded">
-                <h2 className="-left">The Challenge</h2>
+                <h2 className="-left">The challenge</h2>
                 <p>With climate change already upon us, a growing number of communities, companies, and civil society organizations are looking to assess climate vulnerability and to develop resilience plans. However, efforts to turn data into actionable plans are constrained by two challenges:</p>
                 <ul>
                   <li>Robust, actionable data are limited.</li>

--- a/app/scripts/components/Insights/index.jsx
+++ b/app/scripts/components/Insights/index.jsx
@@ -78,7 +78,7 @@ class InsightsPage extends React.Component {
           <div className="row align-center">
             <div className="column small-12 medium-8">
               <h2>Find data-driven stories and tools that spotlight specific climate-related risks
-                and solutions.
+                and solutions
               </h2>
               <p>In PREP’s next phase, any user will be able to <Link to="create">create</Link> and
                 share their own dashboards and insights.</p>

--- a/app/scripts/components/Modal/WelcomeModal.jsx
+++ b/app/scripts/components/Modal/WelcomeModal.jsx
@@ -14,7 +14,7 @@ class WelcomeModal extends React.Component {
       <div className="m-content">
         <article>
           <h2>{this.props.title}</h2>
-          <p>The PREP Platform is currently in beta. While we hope everything is running smoothly, we're still in the process of testing and validating the platform. Please feel free to send us a message at info@prepdata.org if you see any errors or issues.</p>
+          <p>The PREP Platform is currently in beta. While we hope everything is running smoothly, we are still in the process of testing and validating the platform. Please feel free to send us a message at info@prepdata.org if you see any errors or issues.</p>
           <p className="-small"><strong>DISCLAIMER:</strong> YOU AGREE THAT YOUR USE OF THE SITE AND ITS CONTENT IS AT YOUR SOLE RISK. WE MAKE NO PROMISES OR COMMITMENTS ABOUT THE SITE OR ITS CONTENT, AND THE SITE AND CONTENT ARE PROVIDED ON AN “AS IS” BASIS AND WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED. TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, STATUTORY, EXPRESS OR IMPLIED, INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.</p>
         </article>
         <aside>

--- a/app/scripts/components/Partnership/DataAccessibility.jsx
+++ b/app/scripts/components/Partnership/DataAccessibility.jsx
@@ -9,9 +9,19 @@ class DataAccessibility extends React.Component {
       <div className="c-partnership">
 
         <Article>
-          <p>Entities that work to ensure interoperability in access and use of climate-relevant data and information.</p>
-          <p>The Data Workgroup endeavors to identify and reduce the barriers to accessing, contributing, and using data for climate resilience. It promotes standards to ensure interoperability in access and use of climate-relevant data and information.</p>
-          <p>The Data Workgroup is co-led by the Federation of Earth Science Information Partners (ESIP) and NASA.</p>
+          <p>The Data Workgroup strives to ensure interoperability in access and use of climate-relevant data and information. The group aims to identify and reduce the barriers to discovering, accessing, contributing, and using data for climate resilience. It promotes standards and best practices for data interoperability across the private and public sectors.
+          </p>
+          <p>The Data Workgroup is co-led by the Federation of Earth Science Information Partners (ESIP) and NASA.
+          </p>
+          <p>PREP Data Workgroup activities will include:
+          </p>
+          <ol>
+            <li>Providing a forum to discuss and document lessons learned discovering and accessing climate data.</li>
+            <li>Prototyping solutions for improved climate data interoperability.</li>
+            <li>Providing feedback to improve datasets, closing the loop between data providers and users.</li>
+          </ol>
+          <p>To get involved please submit your letter of interest below.
+          </p>
         </Article>
 
         <Article>

--- a/app/scripts/components/Partnership/EngagementWorkgroup.jsx
+++ b/app/scripts/components/Partnership/EngagementWorkgroup.jsx
@@ -7,11 +7,13 @@ class EngagementWorkgroup extends React.Component {
   render() {
     return (
       <div className="c-partnership">
-
         <Article>
-          <p>Entities that help develop, engage, or mobilize user communities to understand the information needs of those seeking to build preparedness and resilience.</p>
-          <p>Effective climate resilience and preparedness planning often requires information specific to a region or community—or even to a sector or project within that region or community. That is why PREP engages with communities around the world to understand information needs at the local, regional and sectoral levels.</p>
-          <p>The Engagement Workgroup is co-led by Future Earth and World Resources Institute</p>
+          <p>The Engagement Workgroup helps develop, engage, or mobilize user communities to understand the information needs of those seeking to build preparedness and resilience, and organizations that help integrate PREP with complementary efforts around the world.
+          </p>
+          <p>Effective climate resilience and preparedness planning often requires information specific to a region or community-or even to a sector or project within that region or community. That is why PREP engages with communities around the world to understand information needs at the local, regional and sectoral levels and coordinates globally with other preparedness and resilience efforts.
+          </p>
+          <p>The Engagement Workgroup is led by Future Earth and co-led by World Resources Institute.
+          </p>
         </Article>
 
         <Article>

--- a/app/scripts/components/Partnership/PlatformWorkgroup.jsx
+++ b/app/scripts/components/Partnership/PlatformWorkgroup.jsx
@@ -9,7 +9,7 @@ class PlatformWorkgroup extends React.Component {
       <div className="c-partnership">
 
         <Article>
-          <p>Entities that collaborate on building platforms to enhance access and usability of data.</p>
+          <p>The Platform Workgroup collaborates on building platforms to enhance access and usability of data.</p>
           <p>The PREP platform, currently in beta, is designed to help users access climate relevant data, explore insights from those data, and compile relevant data and tools in their own dashboards.</p>
           <p>The Platform Workgroup is co-led by World Resources Institute and the U.S. Department of the Interior (DOI).</p>
         </Article>

--- a/app/scripts/components/Partnership/index.jsx
+++ b/app/scripts/components/Partnership/index.jsx
@@ -24,16 +24,16 @@ class Partnership extends React.Component {
 
               <h3>Engagement</h3>
 
-              <p>We will promote collaboration among data and information producers and users.</p>
+              <p>We promote collaboration among data and information producers and users.</p>
               <Link to="/about/engagement">Go to engagement</Link>
 
               <h3>Data</h3>
-              <p>We will seek to reduce the barriers to accessing, contributing, and using data for
+              <p>We seek to reduce the barriers to accessing, contributing, and using data for
                 climate resilience.</p>
               <Link to="/about/data">Go to data</Link>
 
               <h3>Platforms</h3>
-              <p>We will develop platforms to enhance access to and usability of climate-relevant
+              <p>We develop platforms to enhance access to and usability of climate-relevant
                 data and information.</p>
               <Link to="/about/platforms">Go to platforms</Link>
 
@@ -103,8 +103,8 @@ class Partnership extends React.Component {
           <div className="row align-center">
             <div className="column small-12 medium-8">
               <h2>The role of PREP partners</h2>
-              <p>PREP is built on a global network of collaborators from the public and private
-                sectors and from civil society. Each partner participates in at least one PREP
+              <p>PREP is built on a global network of collaborators from the public sector, private
+                sector and civil society. Each partner participates in at least one PREP
                 workgroup.
               </p>
 

--- a/app/scripts/components/Resources/index.jsx
+++ b/app/scripts/components/Resources/index.jsx
@@ -23,7 +23,7 @@ function Resources() {
 
       <Article no-border>
         <p>Find selected resources for understanding the impacts of climate change,
-          tools for building resilience to climate change, and finding additional
+          tools for building resilience to climate change, and additional
           climate relevant data.
         </p>
       </Article>
@@ -78,7 +78,7 @@ function Resources() {
       </Article>
 
       <Article grid="small-12">
-        <h2>Climate Resilience Tools and Services</h2>
+        <h2>Climate resilience tools and services</h2>
 
         <div className="row align-stretch">
           <div className="columns small-12 medium-4">
@@ -183,7 +183,7 @@ function Resources() {
       </Article>
 
       <Article grid="small-12">
-        <h2>Climate Data Portals</h2>
+        <h2>Climate data portals</h2>
 
         <div className="row align-stretch">
           <div className="columns small-12 medium-4">
@@ -232,10 +232,10 @@ function Resources() {
               <Thumbnail
                 url={'http://iridl.ldeo.columbia.edu/index.html'}
                 src={iriLogo}
-                alt={'IRI/LDEO climate data Library'}
+                alt={'IRI/LDEO Climate Data Library'}
                 border={'neutral'}
               />
-              <h3>IRI/LDEO climate data Library</h3>
+              <h3>IRI/LDEO Climate Data Library</h3>
               <p>
                 The IRI Data Library is an online data repository and analysis tool that allows a user to view, analyze,
                 and download hundreds of terabytes of climate-related data through a standard web browser

--- a/app/scripts/components/SummaryCards/index.jsx
+++ b/app/scripts/components/SummaryCards/index.jsx
@@ -17,7 +17,7 @@ const cards = {
       className="simple-card -inverse"
       style={{ backgroundImage: `url(${bg.insights})` }}>
       <h3>Insights</h3>
-      <p>Integer id placerat ligula, eget consequat sapien. Duis nec neque scelerisque</p>
+      <p>Find data-driven stories and tools that spotlight specific climate-related risks and solutions</p>
       <Link to="/insights">EXPLORE THE INSIGHTS</Link>
     </div>),
   dashboards: (
@@ -25,7 +25,7 @@ const cards = {
       className="simple-card -inverse"
       style={{ backgroundImage: `url(${bg.dashboards})` }}>
       <h3>Dashboards</h3>
-      <p>Integer id placerat ligula, eget consequat sapien. Duis nec neque scelerisque</p>
+      <p>Find collections of climate risk data, insights, and tools contributed by partner communities</p>
       <Link to="/dashboards">EXPLORE THE DASHBOARDS</Link>
     </div>)
 }
@@ -38,7 +38,7 @@ class SummaryCards extends React.Component {
       <div className="c-summary-cards">
         <div className="simple-card -inverse" style={{ backgroundImage: `url(${bg.explore})` }}>
           <h3>Data on the map</h3>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+          <p>Find datasets from local, national and other sources</p>
           <Link to="/explore">EXPLORE THE MAP</Link>
         </div>
 

--- a/app/scripts/metadata.json
+++ b/app/scripts/metadata.json
@@ -43,18 +43,18 @@
   {
     "name": "data-accessibility",
     "pathname": "/about/data",
-    "metaTitle": "Data Accessibility Workgroup",
+    "metaTitle": "Data Workgroup",
     "metaDescription": "",
-    "title": "Data Accessibility Workgroup",
+    "title": "Data Workgroup",
     "bannerSize": "small",
     "bannerBg": "partnershipData"
   },
   {
     "name": "platform-development",
     "pathname": "/about/platforms",
-    "metaTitle": "Platform Development Workgroup",
+    "metaTitle": "Platform Workgroup",
     "metaDescription": "",
-    "title": "Platform Development Workgroup",
+    "title": "Platform Workgroup",
     "bannerSize": "small",
     "bannerBg": "partnershipPlatforms"
   },


### PR DESCRIPTION
Hi @davidsingal, 
I did another pass through the site for copy editing and to address the tickets that weren't clear. Also I noticed that when you fixed the code style last time, there were a few spots on the Create page where link tags were broken onto new lines, removing the space after the link in the sentence. 

- Check for capitalization and punctuation
- Add Whats Next to FAQ
- Rename "from" to "source" on explore sidebar push to new line
- Rename "source" to "access" on dataset detail page
- Update text on workgroup pages
- Fix spaces on Create page
- Move static text below summary on dashboards
- New text for summary cards
- Rename Platform Development to Platform Workgroup, Data Accessibility to Data Workgroup