### PR TITLE
change the dashboard detail summary to content

### DIFF
--- a/app/scripts/components/Dashboards/DashboardDetail.jsx
+++ b/app/scripts/components/Dashboards/DashboardDetail.jsx
@@ -87,8 +87,9 @@ class DashboardDetail extends React.Component {
           dashboardSlug={this.props.dashboardSlug}
           currentSection="dashboards"
         >
-          <p dangerouslySetInnerHTML={{__html:this.props.data.summary }}></p>
-          <p>This is an initial list of insights, data and tools that are important for our work.</p>
+          <p dangerouslySetInnerHTML={{ __html:this.props.data.content }}></p>
+          <p>This is an initial list of insights, data and tools that are important for our work.
+          </p>
         </SectionIntro>
 
         <NavTab


### PR DESCRIPTION
This pull request contains:

Changes to the _dashboardDetail_ intro text: from _data.summary_ to _data.content_.