### PR TITLE
fixed issue where legend units were always uppercased

### DIFF
--- a/app/scripts/components/Explore/ExploreLegend.jsx
+++ b/app/scripts/components/Explore/ExploreLegend.jsx
@@ -97,9 +97,10 @@ const SortableItem = SortableElement(({layer, index, onInfoClick, toggleLayerOpa
         <DragHandle />
         <div className="column small-10">
           <span className="title">{layer.title}
-            {layer.attributes['legend-config'].unit &&
-              ` (${layer.attributes['legend-config'].unit})`
-            }
+            <span className="-units">
+              {layer.attributes['legend-config'].unit &&
+              ` (${layer.attributes['legend-config'].unit})`}
+            </span>
           </span>
         </div>
         <div className="column small-2 layer-actions">
@@ -201,7 +202,7 @@ DataMapLegend.propTypes = {
   */
   onInfoClick: React.PropTypes.func.isRequired,
   /**
-  * Define the function to the toglle the layer opacity
+  * Define the function to the toggle the layer opacity
   */
   toggleLayerOpacity: React.PropTypes.func.isRequired,
   /**

--- a/app/scripts/components/Explore/ExploreMap.jsx
+++ b/app/scripts/components/Explore/ExploreMap.jsx
@@ -3,14 +3,14 @@ import LoadingSpinner from '../Loading/LoadingSpinner';
 import React from 'react';
 
 class ExploreMap extends React.Component {
-  constructor () {
+  constructor() {
     super();
     this.state = {
       loading: false
     };
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.initMap();
     this.setMapParams();
     this.setMapListeners();
@@ -22,11 +22,11 @@ class ExploreMap extends React.Component {
     }, 0);
   }
 
-  componentWillReceiveProps (props) {
+  componentWillReceiveProps(props) {
     this.updateDatasets(props.data, props.layers);
   }
 
-  setMapListeners () {
+  setMapListeners() {
     this.map.on('dragend', () => {
       this.setMapParams();
     });
@@ -35,7 +35,7 @@ class ExploreMap extends React.Component {
     });
   }
 
-  getMapParams () {
+  getMapParams() {
     const latLng = this.map.getCenter();
     return {
       zoom: this.map.getZoom(),
@@ -46,11 +46,11 @@ class ExploreMap extends React.Component {
     };
   }
 
-  setMapParams () {
+  setMapParams() {
     this.props.setMapParams(this.getMapParams());
   }
 
-  initMap () {
+  initMap() {
     const { params } = this.context.location;
 
     if (!params.zoom) params.zoom = 3;
@@ -73,7 +73,7 @@ class ExploreMap extends React.Component {
     ).addTo(this.map, 1);
   }
 
-  updateDatasets (newData, newLayers) {
+  updateDatasets(newData, newLayers) {
     const datasets = newData || this.props.data;
     const layers = newLayers || this.props.layers;
     this.hasActiveLayers = false;
@@ -86,20 +86,20 @@ class ExploreMap extends React.Component {
     }
   }
 
-  wasAlreadyAdded (dataset) {
+  wasAlreadyAdded(dataset) {
     return this.mapLayers[dataset.layers[0].layer_id] || false;
   }
 
-  hasChangedOrder (dataset) {
+  hasChangedOrder(dataset) {
     return dataset.index !== undefined && dataset.index !== this.mapLayers[dataset.layers[0].layer_id].index || false;
   }
 
-  hasChangedOpacity (dataset) {
+  hasChangedOpacity(dataset) {
     let hasChanged = (dataset && dataset.opacity !== this.mapLayers[dataset.layers[0].layer_id].options.opacity) || false;
     return hasChanged;
   }
 
-  isLayerReady (dataset, layers) {
+  isLayerReady(dataset, layers) {
     if (dataset.layers && dataset.layers.length) {
       const layerId = dataset.layers[0].layer_id;
       return layers && layers[layerId] || false;
@@ -151,7 +151,7 @@ class ExploreMap extends React.Component {
     }
   }
 
-  changeLayerOpacity (dataset) {
+  changeLayerOpacity(dataset) {
     const layer = this.mapLayers[dataset.layers[0].layer_id];
     layer.setOpacity(dataset.opacity);
   }
@@ -318,25 +318,25 @@ class ExploreMap extends React.Component {
       });
   }
 
-  removeMapLayer (layerId) {
+  removeMapLayer(layerId) {
     this.map.removeLayer(this.mapLayers[layerId]);
     delete this.mapLayers[layerId];
   }
 
-  handleTileLoaded () {
+  handleTileLoaded() {
     this.setState({
       loading: false
     });
   }
 
-  handleTileError (layer) {
+  handleTileError(layer) {
     if (this.mapLayers[layer.id]) {
       this.removeMapLayer(layer);
     }
     this.props.onTileError(layer.id);
   }
 
-  render () {
+  render() {
     let loading;
     if (this.state.loading && this.hasActiveLayers) {
       loading = <LoadingSpinner />;

--- a/app/styles/components/_explore-legend.scss
+++ b/app/styles/components/_explore-legend.scss
@@ -161,6 +161,12 @@
     }
   }
 
+  .title {
+    .-units {
+      text-transform: none;
+    }
+  }
+
   .layer-actions {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This pull request contains:

- A new scss class in explore-legend styles called title.
- A new scss subclass in explore-legend styles called units.

Changes the legend title units to no text-transform.