### PR TITLE
sharing layers in initial order fix

### DIFF
--- a/app/scripts/actions/datasets.js
+++ b/app/scripts/actions/datasets.js
@@ -82,7 +82,7 @@ export function getDatasets(defaultActiveLayers) {
               const index = defaultActiveLayers.indexOf(datasets[i].id);
               if (index > -1) {
                 datasets[i].active = true;
-                datasets[i].index = index + 1;
+                datasets[i].index = i + 1;
                 datasets[i].opacity = 1;
               }
             }

--- a/app/scripts/actions/exploremap.js
+++ b/app/scripts/actions/exploremap.js
@@ -6,6 +6,8 @@ import {
   MAP_LAYER_OPACITY_CHANGED
 } from '../constants';
 
+import { updateURL } from './links';
+
 export function updateMapParams(params) {
   return {
     type: MAP_DATA_CHANGED,
@@ -28,9 +30,12 @@ export function setSwitchStatus(id, status) {
 }
 
 export function setLayersOrder(layers) {
-  return {
-    type: MAP_LAYERS_ORDER_CHANGED,
-    payload: layers
+  return dispatch => {
+    dispatch({
+      type: MAP_LAYERS_ORDER_CHANGED,
+      payload: layers
+    });
+    dispatch(updateURL());
   };
 }
 


### PR DESCRIPTION
This pull request contains:

- More reliable way to get the original order of the layers when opening a shared map.
- URL state update after changing the dataset layers order.

