### PR TITLE
fixed sharing layers in order

### DIFF
--- a/app/scripts/actions/datasets.js
+++ b/app/scripts/actions/datasets.js
@@ -82,7 +82,7 @@ export function getDatasets(defaultActiveLayers) {
               const index = defaultActiveLayers.indexOf(datasets[i].id);
               if (index > -1) {
                 datasets[i].active = true;
-                datasets[i].index = i + 1;
+                datasets[i].index = index + 1;
                 datasets[i].opacity = 1;
               }
             }


### PR DESCRIPTION
This pull request contains:

- Original way to get the order of the layers when sharing a map.
- Corrects the wrong order issue!