### PR TITLE
Create a widget from the dataset page

### DIFF
--- a/app/scripts/components/Dataset/index.jsx
+++ b/app/scripts/components/Dataset/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import URI from 'urijs';
-import WidgetEditor from 'widget-editor';
+import { connect } from 'react-redux';
+import WidgetEditor, { modalActions, SaveWidgetModal } from 'widget-editor';
 
 import metadata from '../../metadata.json';
 import PartnersSlider from '../../containers/PartnersSlider';
@@ -24,6 +26,25 @@ class DatasetDetail extends React.Component {
   componentWillMount() {
     if (!this.props.data || !this.props.widgets.length) {
       this.props.getDatasetData(this.props.datasetSlug);
+    }
+  }
+
+  /**
+   * Callback executed when the user clicks the save button of
+   * the widget editor
+   */
+  onSaveWidget() {
+    if (this.getWidgetConfig) {
+      this.props.toggleModal(true, {
+        children: SaveWidgetModal,
+        childrenProps: {
+          datasetId: this.props.data.id,
+          getWidgetConfig: this.getWidgetConfig,
+          onClickCheckWidgets: () => {
+            window.location = '/myprep/widgets/my_widgets';
+          }
+        }
+      });
     }
   }
 
@@ -171,10 +192,10 @@ class DatasetDetail extends React.Component {
           { (data.id && data.id !== 'defe21a1-f6a0-4bf7-a9ee-f083456130de') && (
             <WidgetEditor
               datasetId={data.id}
-              saveButtonMode="never"
               embedButtonMode="never"
-              titleMode="never"
               mapConfig={{ zoom: 3, lat: 40.65, lng: -98.21 }}
+              provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
+              onSave={() => this.onSaveWidget()}
             />
           ) }
 
@@ -215,27 +236,34 @@ DatasetDetail.propTypes = {
   /**
    * Define the route path (from the router)
    */
-  currentPage: React.PropTypes.string,
+  currentPage: PropTypes.string,
   /**
    * Define the slug of the dataset
    */
-  datasetSlug: React.PropTypes.string.isRequired,
+  datasetSlug: PropTypes.string.isRequired,
   /**
    * Define the function to get the datataset detail data
    */
-  getDatasetData: React.PropTypes.func.isRequired,
+  getDatasetData: PropTypes.func.isRequired,
   /**
    * Define the dataset data
    */
-  data: React.PropTypes.any,
+  data: PropTypes.any,
   /**
    * Define the dataset widget
    */
-  widgets: React.PropTypes.array
+  widgets: PropTypes.array,
+
+  // REDUX
+  toggleModal: PropTypes.func
 };
 
 DatasetDetail.defaultProps = {
   data: {}
 };
 
-export default DatasetDetail;
+const mapDispatchToProps = dispatch => ({
+  toggleModal: (...params) => dispatch(modalActions.toggleModal(...params))
+});
+
+export default connect(null, mapDispatchToProps)(DatasetDetail);

--- a/app/scripts/components/auth/auth.js
+++ b/app/scripts/components/auth/auth.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { setConfig } from 'widget-editor';
 
 import { browserHistory } from 'react-router';
 import actions from './auth-actions';
@@ -20,6 +21,9 @@ class AuthContainer extends Component {
     } else {
       browserHistory.push('/');
     }
+
+    // We update the widget editor's config
+    setConfig({ userToken: token || null });
   }
 
   handleAuthenticationAction() {

--- a/app/scripts/components/user/user.js
+++ b/app/scripts/components/user/user.js
@@ -2,6 +2,7 @@ import { Component, createElement } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
+import { setConfig } from 'widget-editor';
 
 import { browserHistory } from 'react-router';
 
@@ -47,6 +48,7 @@ class UserContainer extends Component {
     localStorage.removeItem('token');
     this.props.updateUserData({});
     this.props.logOutSuccess(false);
+    setConfig({ userToken: null });
     browserHistory.push('/');
   }
 

--- a/app/scripts/index.jsx
+++ b/app/scripts/index.jsx
@@ -32,7 +32,8 @@ setConfig({
   url: process.env.RW_API_URL,
   env: process.env.DATASET_ENV,
   applications: process.env.APPLICATIONS,
-  authUrl: 'https://api.resourcewatch.org/auth'
+  authUrl: 'https://api.resourcewatch.org/auth',
+  userToken: sessionStorage.getItem('token') || null
 });
 
 /**

--- a/app/scripts/index.jsx
+++ b/app/scripts/index.jsx
@@ -14,7 +14,7 @@ import { syncHistoryWithStore, routerReducer, routerMiddleware } from 'react-rou
 import * as reducers from './reducers';
 import Routes from './routes';
 import { reducers as widgetEditorReducers, setConfig } from 'widget-editor';
-import 'widget-editor/dist/styles.css';
+import 'widget-editor/dist/styles.min.css';
 
 
 // Modules
@@ -33,7 +33,8 @@ setConfig({
   env: process.env.DATASET_ENV,
   applications: process.env.APPLICATIONS,
   authUrl: 'https://api.resourcewatch.org/auth',
-  userToken: sessionStorage.getItem('token') || null
+  userToken: sessionStorage.getItem('token') || null,
+  assetsPath: '/images/'
 });
 
 /**

--- a/app/styles/components/_widget-editor.scss
+++ b/app/styles/components/_widget-editor.scss
@@ -195,3 +195,9 @@
     }
   }
 }
+
+.c-save-widget-modal {
+  .c-field-container {
+    border: 0;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "webpack-dev-middleware": "1.12.2",
     "webpack-merge": "4.1.0",
     "whatwg-fetch": "2.0.3",
-    "widget-editor": "0.0.7"
+    "widget-editor": "0.0.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,8 +59,8 @@ ajv@^4.7.0, ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.3.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -1088,6 +1088,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-64@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+
 base64-js@1.2.1, base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
@@ -1620,6 +1624,10 @@ clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
 
+clone@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
 clone@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.2.0.tgz#c6126a90ad4f72dbf5acdb243cc37724fe93fc1f"
@@ -1729,6 +1737,10 @@ component-classes@^1.2.5:
   resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
   dependencies:
     component-indexof "0.0.3"
+
+component-emitter@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.0.tgz#ccd113a86388d06482d03de3fc7df98526ba8efe"
 
 component-indexof@0.0.3:
   version "0.0.3"
@@ -3494,6 +3506,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-params@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/get-params/-/get-params-0.1.2.tgz#bae0dfaba588a0c60d7834c0d8dc2ff60eeef2fe"
+
 get-proxy@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/get-proxy/-/get-proxy-1.1.0.tgz#894854491bc591b0f147d7ae570f5c678b7256eb"
@@ -4311,8 +4327,8 @@ is-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
 
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz#5a846777e2c2620d1e69104e5d3a03b1f6088f11"
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.0.tgz#33f576b0dce46bf34328a7d471ef7ceab77a524d"
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
@@ -4535,6 +4551,10 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
+jsan@^3.1.0, jsan@^3.1.5:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.9.tgz#2705676c1058f0a7d9ac266ad036a5769cfa7c96"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -4687,6 +4707,10 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+linked-list@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/linked-list/-/linked-list-0.1.0.tgz#798b0ff97d1b92a4fd08480f55aea4e9d49d37bf"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -6305,7 +6329,7 @@ querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
-querystring@0.2.0:
+querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
@@ -6519,8 +6543,8 @@ react-leaflet@1.7.8:
     warning "^3.0.0"
 
 react-markdown@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.1.1.tgz#8edc42ee958e6a33f6fddc21f24d26ac96faa005"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.1.3.tgz#5ac1f20cb5a3e8c47b6ae3c8522e813b08f58c34"
   dependencies:
     prop-types "^15.6.0"
     remark-parse "^4.0.0"
@@ -6755,6 +6779,13 @@ reduce-reducers@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.2.tgz#fa1b4718bc5292a71ddd1e5d839c9bea9770f14b"
 
+redux-devtools-instrument@^1.3.3:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.2.tgz#5e91cfe402e790dae3fd2f0d235f7b7d84b09ffe"
+  dependencies:
+    lodash "^4.2.0"
+    symbol-observable "^1.0.2"
+
 redux-thunk@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
@@ -6874,6 +6905,33 @@ remark-parse@^4.0.0:
     unist-util-remove-position "^1.0.0"
     vfile-location "^2.0.0"
     xtend "^4.0.1"
+
+remote-redux-devtools@^0.5.12:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/remote-redux-devtools/-/remote-redux-devtools-0.5.12.tgz#42cb95dfa9e54c1d9671317c5e7bba41e68caec2"
+  dependencies:
+    jsan "^3.1.5"
+    querystring "^0.2.0"
+    redux-devtools-instrument "^1.3.3"
+    remotedev-utils "^0.1.1"
+    rn-host-detect "^1.0.1"
+    socketcluster-client "^5.3.1"
+
+remotedev-serialize@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.0.tgz#074768e98cb7aa806f45994eeb0c8af95120ee32"
+  dependencies:
+    jsan "^3.1.0"
+
+remotedev-utils@^0.1.1:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/remotedev-utils/-/remotedev-utils-0.1.4.tgz#643700819a943678073c75eb185e81d96620b348"
+  dependencies:
+    get-params "^0.1.2"
+    jsan "^3.1.5"
+    lodash "^4.0.0"
+    remotedev-serialize "^0.1.0"
+    shortid "^2.2.6"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -7068,9 +7126,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rn-host-detect@^1.0.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rn-host-detect/-/rn-host-detect-1.1.3.tgz#242d76e2fa485c48d751416e65b7cce596969e91"
+
 rollup-plugin-babel@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz#a2765dea0eaa8aece351c983573300d17497495b"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz#63adedc863130327512a4a9006efc2241c5b7c15"
   dependencies:
     rollup-pluginutils "^1.5.0"
 
@@ -7140,6 +7202,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, 
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+safe-buffer@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -7162,6 +7228,26 @@ sass-loader@6.0.6:
 sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+sc-channel@~1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/sc-channel/-/sc-channel-1.0.6.tgz#b38bd47a993e78290fbc53467867f6b2a0a08639"
+  dependencies:
+    sc-emitter "1.x.x"
+
+sc-emitter@1.x.x, sc-emitter@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sc-emitter/-/sc-emitter-1.1.0.tgz#ef119d4222f4c64f887b486964ef11116cdd0e75"
+  dependencies:
+    component-emitter "1.2.0"
+
+sc-errors@~1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/sc-errors/-/sc-errors-1.3.3.tgz#c00bc4c766a970cc8d5937d08cd58e931d7dae05"
+
+sc-formatter@~3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sc-formatter/-/sc-formatter-3.0.1.tgz#c8b3fec0eea51b883dbc22ddfeacb46cd0e8db6c"
 
 schema-utils@^0.3.0:
   version "0.3.0"
@@ -7318,6 +7404,10 @@ shelljs@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
 
+shortid@^2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -7355,6 +7445,20 @@ sntp@2.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
   dependencies:
     hoek "4.x.x"
+
+socketcluster-client@^5.3.1:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/socketcluster-client/-/socketcluster-client-5.5.2.tgz#9d4369e0e722ff7e55e5422c2d44f5afe1aff128"
+  dependencies:
+    base-64 "0.1.0"
+    clone "2.1.1"
+    linked-list "0.1.0"
+    querystring "0.2.0"
+    sc-channel "~1.0.6"
+    sc-emitter "~1.1.0"
+    sc-errors "~1.3.0"
+    sc-formatter "~3.0.0"
+    ws "3.0.0"
 
 sort-keys@^1.0.0:
   version "1.1.2"
@@ -8043,6 +8147,10 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -8462,9 +8570,9 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-widget-editor@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-0.0.7.tgz#dac8b0c17ec018f276340681e6531998b8c91f68"
+widget-editor@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-0.0.8.tgz#beeb37a9c451c9fa1c4b46ca8cc602581df4da10"
   dependencies:
     autobind-decorator "^2.1.0"
     babel-runtime "^6.26.0"
@@ -8532,6 +8640,13 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+ws@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.0.0.tgz#98ddb00056c8390cb751e7788788497f99103b6c"
+  dependencies:
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
 
 x-is-function@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This PR lets the logged user create widgets in the API from the dataset page. It also switches to the v0.0.8 of the [widget editor](https://github.com/resource-watch/widget-editor).

When clicking on "Check my widgets", note that the redirection is not working on this repository because the URL points to the prep-manager app.