### PR TITLE
NexGDDP: enable pan after moving the divider

### DIFF
--- a/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import L from 'leaflet';
 import { Map, TileLayer, ZoomControl, Marker } from 'react-leaflet';
 import Control from 'react-leaflet-control';
-import 'lib/leaflet-side-by-side';
+import 'lib/leaflet-side-by-side/leaflet-side-by-side';
 
 // Redux
 import { getLayers } from 'selectors/nexgddptool';


### PR DESCRIPTION
This PR fix the issue with the compare map. After moving the divider you couldn't pan again. I change the library