### PR TITLE
Editor: Update to v0.1.0

### DIFF
--- a/app/styles/components/_widget-editor.scss
+++ b/app/styles/components/_widget-editor.scss
@@ -1,4 +1,4 @@
-.c-widget-editor {
+.c-we-widget-editor {
   max-width: rem($max-width);
   margin: 0 auto;
 
@@ -15,15 +15,15 @@
     }
   }
 
-  .c-columnbox {
+  .c-we-columnbox {
     color: $base-font-color;
     background-color: $light-gold;
 
-    .c-icon { fill: $base-font-color; }
+    .c-we-icon { fill: $base-font-color; }
     .order-by { color: $base-font-color; }
   }
 
-  .c-column-container {
+  .c-we-column-container {
     .columnbox-container {
       &.-release {
         border-color: $base-font-color;
@@ -33,7 +33,7 @@
     }
   }
 
-  .c-filter-container {
+  .c-we-filter-container {
     .filter-box {
       &.-release {
         border-color: $base-font-color;
@@ -43,7 +43,7 @@
     }
   }
 
-  .c-map {
+  .c-we-map {
     .leaflet-control-attribution {
       a {
         display: inline;
@@ -66,7 +66,7 @@
     }
   }
 
-  .c-map-controls {
+  .c-we-map-controls {
     .map-controls-item {
       margin: 0;
 
@@ -74,7 +74,7 @@
     }
   }
 
-  .c-legend-map {
+  .c-we-legend-map {
     .legend-title {
       font-family: $base-font-family;
 
@@ -95,10 +95,10 @@
   }
 }
 
-.c-widget-editor,
-.c-tooltip-editor,
-.c-modal-editor {
-  .c-spinner {
+.c-we-widget-editor,
+.c-we-tooltip,
+.c-we-modal {
+  .c-we-spinner {
     .spinner-box {
       .icon {
         border-top-color: $base-font-color;
@@ -106,9 +106,12 @@
     }
   }
 
-  .c-button,
-  .c-btn {
+  .c-we-button,
+  .c-we-btn {
+    @extend .c-button;
+
     &.-primary {
+      color: $white;
       background: $base-font-color;
     }
 
@@ -117,16 +120,21 @@
 
       &:hover { background: rgba($base-font-color, 0.1); }
     }
+
+    &:hover {
+      transform: none;
+      box-shadow: none;
+    }
   }
 
-  .c-checkbox {
+  .c-we-checkbox {
     .checkbox-icon,
     .checkbox-icon:after {
       border-color: $base-font-color;
     }
   }
 
-  .c-radio {
+  .c-we-radio {
     label {
       span {
         border-color: $base-font-color;
@@ -136,9 +144,9 @@
     }
   }
 
-  .c-chart-editor {
+  .c-we-chart {
     .save-widget-container {
-      .c-button {
+      .c-we-button {
         margin: 0;
         line-height: 45px;
       }
@@ -146,7 +154,7 @@
   }
 }
 
-.c-filter-string-tooltip {
+.c-we-filter-string-tooltip {
   .rc-slider-rail { background: $pale-grey; }
   .rc-slider-track { background: $base-font-color; }
   .rc-slider-handle {
@@ -160,7 +168,7 @@
   }
 }
 
-.c-legend-unit {
+.c-we-legend-unit {
   .-dark {
     color: $base-font-color;
     font-family: $base-font-family;
@@ -168,7 +176,7 @@
   }
 }
 
-.c-custom-select {
+.c-we-custom-select {
   &:after { border-bottom-color: $base-font-color; }
 
   .custom-select-text {
@@ -180,12 +188,12 @@
 
   .custom-select-options {
     .next {
-      .c-icon { fill: $base-font-color; }
+      .c-we-icon { fill: $base-font-color; }
     }
 
     & > li {
       & > div {
-        .c-icon { fill: $base-font-color; }
+        .c-we-icon { fill: $base-font-color; }
 
         span {
           font-family: $base-font-family;
@@ -197,8 +205,8 @@
   }
 }
 
-.c-save-widget-modal {
-  .c-field-container {
+.c-we-save-widget-modal {
+  .c-we-field-container {
     border: 0;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12788,9 +12788,9 @@
       }
     },
     "widget-editor": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.0.9.tgz",
-      "integrity": "sha512-bNLycjyqg86YRSuUuA9+oEHjzDh55fxBFOxs2wkkr9S2F510HZ5oMR4vvI98L1h2Dtj3aCWWrI6/9/PKfiLFxg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.1.0.tgz",
+      "integrity": "sha1-Ga5WE3+wXge8EwEPEabaptSvsJ4=",
       "requires": {
         "autobind-decorator": "2.1.0",
         "babel-runtime": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "webpack-dev-middleware": "1.12.2",
     "webpack-merge": "4.1.0",
     "whatwg-fetch": "2.0.3",
-    "widget-editor": "0.0.9"
+    "widget-editor": "0.1.0"
   }
 }


### PR DESCRIPTION
This PR updates the widget editor to v0.1.0 which fixes a major bug preventing the restoration of the map widgets.

Because the new version also scopes all its CSS classes, this PR contains updates to the styles overrides.