### PR TITLE
NexGDDP: fix a bug that prevented the user from saving the chart as a widget

### DIFF
--- a/app/scripts/components/Tooltip/ShareNexgddpChartTooltip.jsx
+++ b/app/scripts/components/Tooltip/ShareNexgddpChartTooltip.jsx
@@ -35,7 +35,7 @@ class ShareNexgddpChartTooltip extends React.Component {
       children: SaveWidgetModal,
       childrenProps: {
         datasetId: this.props.datasetId,
-        getWidgetConfig: this.props.generateVegaSpec,
+        getWidgetConfig: this.props.getWidgetConfig,
         onClickCheckWidgets: this.props.onClickCheckWidgets
       }
     });
@@ -56,7 +56,7 @@ class ShareNexgddpChartTooltip extends React.Component {
 ShareNexgddpChartTooltip.propTypes = {
   datasetId: PropTypes.string,
   toggleTooltip: PropTypes.func,
-  generateVegaSpec: PropTypes.func,
+  getWidgetConfig: PropTypes.func,
   onClickCheckWidgets: PropTypes.func,
   toggleEditorModal: PropTypes.func
 };


### PR DESCRIPTION
This PR fixes a bug that prevented the user from saving the chart as a widget in the NexGDDP tool.

You can test the fix by opening the modal to save the chart. You shouldn't see any error in the console.

[Pivotal task (first sub-task)](https://www.pivotaltracker.com/story/show/154279052)