### PR TITLE
Fix layout spacing of the social nav to align with designs

### DIFF
--- a/app/scripts/components/App/index.jsx
+++ b/app/scripts/components/App/index.jsx
@@ -118,10 +118,10 @@ class App extends React.Component {
           }
           <div className="l-footer-down">
             <div className="row">
-              <div className="column small-6 align-middle">
+              <div className="column small-12 medium-12 large-6 align-middle">
                 <SocialNav />
               </div>
-              <div className="column small-6 align-middle">
+              <div className="column small-6 medium-12 large-6 align-middle">
                 <SecondaryNav />
               </div>
             </div>

--- a/app/scripts/components/Navigation/SocialNav.jsx
+++ b/app/scripts/components/Navigation/SocialNav.jsx
@@ -5,12 +5,10 @@ function SocialNav() {
   return (
     <nav className="c-nav -social">
       <ul>
-        <li>
+        <li className="social-links">
           <a href={`https://facebook.com/${config.facebookUser}`} target="_blank">
             <Icon name="icon-facebook" className="-extra-large" />
           </a>
-        </li>
-        <li>
           <a href={`https://twitter.com/${config.twitterUser}`} target="_blank">
             <Icon name="icon-twitter" className="-extra-large" />
           </a>

--- a/app/styles/components/_nav.scss
+++ b/app/styles/components/_nav.scss
@@ -110,6 +110,17 @@
         }
       }
     }
+    @media #{$mq-medium} {
+      ul {
+        justify-content: flex-start;
+      }
+    }
+
+    @media #{$mq-large} {
+      ul {
+        justify-content: flex-end;
+      }
+    }
   }
 
   &.-social {
@@ -127,21 +138,34 @@
       }
     }
 
-    .powered-by {
+    .social-links {
+      padding-right: 20px;
       position: relative;
-      margin-top: rem(5);
+      margin-right: 20px;
 
-      &:before {
+      &:after {
         display: block;
         content: "";
         position: absolute;
         top: rem(6);
-        left: rem(-16);
+        right: 0;
         width: 1px;
         height: rem(13);
-
         background-color: $bay-of-many;
       }
+
+      a {
+        line-height: 0;
+      }
+
+      a:not(:last-child) {
+        margin-right: 20px;
+      }
+    }
+
+    .powered-by {
+      position: relative;
+      margin-top: rem(5);
     }
 
     .c-icon {


### PR DESCRIPTION
Amend social nav layout/spacing to align with designs:
*PR does not include updated Facebook icon.*

**dev**
![image](https://user-images.githubusercontent.com/8505382/34942654-b851372e-f9f8-11e7-8f69-46a3b0c70a38.png)

**design**
![image](https://user-images.githubusercontent.com/8505382/34942644-a9cd7e10-f9f8-11e7-91a1-aa81e62a8f7c.png)

