### PR TITLE
Fix explore share control position

### DIFF
--- a/app/styles/components/_share-control.scss
+++ b/app/styles/components/_share-control.scss
@@ -1,7 +1,7 @@
 .c-share-control {
   &.-absolute {
     position: absolute;
-    bottom: 188px;
+    bottom: 174px;
     right: 30px;
     z-index: 1;
 


### PR DESCRIPTION
Fix share control position on the explore map:

![image](https://user-images.githubusercontent.com/8505382/34943172-d8611d7a-f9fa-11e7-9364-bb098b555dcd.png)
