### PR TITLE
NexGDDP: Add a tooltip to the generated widgets

### DIFF
--- a/app/scripts/actions/nexgddptool.js
+++ b/app/scripts/actions/nexgddptool.js
@@ -149,7 +149,7 @@ export function getChartData() {
     const indicatorId = getIndicatorId(state);
     const slug = state.nexgddptool.indicatorDataset.slug;
 
-    return fetch(`${process.env.RW_API_URL}/query?sql=select ${indicatorId}_q25 as q25, ${indicatorId} as q50, ${indicatorId}_q75 as q75, year as date from ${slug}&lat=${lat}&lon=${lng}`)
+    return fetch(`${process.env.RW_API_URL}/query?sql=select ${indicatorId}_q25 as q25, ${indicatorId} as q50, ${indicatorId}_q75 as q75, year as x from ${slug}&lat=${lat}&lon=${lng}`)
       .then((res) => {
         if (res.ok) return res.json();
         throw new Error('Unable to fetch the data of the chart');

--- a/app/scripts/components/nexgddp-tool/tool-chart/TimeseriesChart.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-chart/TimeseriesChart.jsx
@@ -20,7 +20,7 @@ const chartSpec = {
   "data": [
     {
       "name": "table",
-      "format": {"parse": {"date": "date"}},
+      "format": {"parse": {"x": "date"}},
       "values": []
     },
     {
@@ -29,7 +29,7 @@ const chartSpec = {
       "transform": [
         {
           "type": "filter",
-          "test": "year(datum.date) >= utcyear(range1.start) && year(datum.date) <= utcyear(range1.end)"
+          "test": "year(datum.x) >= utcyear(range1.start) && year(datum.x) <= utcyear(range1.end)"
         }
       ]
     },
@@ -39,7 +39,7 @@ const chartSpec = {
       "transform": [
         {
           "type": "filter",
-          "test": "range2 ? (year(datum.date) >= utcyear(range2.start) && year(datum.date) <= utcyear(range2.end)) : false"
+          "test": "range2 ? (year(datum.x) >= utcyear(range2.start) && year(datum.x) <= utcyear(range2.end)) : false"
         }
       ]
     }
@@ -76,7 +76,7 @@ const chartSpec = {
       "type": "utc",
       "range": "width",
       "zero": false,
-      "domain": {"data": "table","field": "date"}
+      "domain": {"data": "table","field": "x"}
     },
     {
       "name": "y",
@@ -147,7 +147,7 @@ const chartSpec = {
       "properties": {
         "enter": {
           "interpolate": {"value": "monotone"},
-          "x": {"scale": "x","field": "date"},
+          "x": {"scale": "x","field": "x"},
           "y": {"scale": "y","field": "q75"},
           "y2": {"scale": "y","field": "q25"},
           "fill": {"value": "#E9ECEE"}
@@ -160,7 +160,7 @@ const chartSpec = {
       "properties": {
         "enter": {
           "interpolate": {"value": "monotone"},
-          "x": {"scale": "x","field": "date"},
+          "x": {"scale": "x","field": "x"},
           "y": {"scale": "y","field": "q50"},
           "stroke": {"value": "#263e57"},
           "strokeWidth": {"value": 2},
@@ -174,7 +174,7 @@ const chartSpec = {
       "properties": {
         "enter": {
           "interpolate": {"value": "monotone"},
-          "x": {"scale": "x","field": "date"},
+          "x": {"scale": "x","field": "x"},
           "y": {"scale": "y","field": "q75"},
           "y2": {"scale": "y","field": "q25"},
           "fillOpacity": {"value": 0},
@@ -207,7 +207,7 @@ const chartSpec = {
       "properties": {
         "enter": {
           "interpolate": {"value": "monotone"},
-          "x": {"scale": "x","field": "date"},
+          "x": {"scale": "x","field": "x"},
           "y": {"scale": "y","field": "q75"},
           "y2": {"scale": "y","field": "q25"},
           "fillOpacity": {"value": 0},
@@ -234,7 +234,36 @@ const chartSpec = {
         }
       }
     }
-  ]
+  ],
+  "interaction_config": [
+    {
+      "name": "tooltip",
+      "config": {
+        "fields": [
+          {
+            "key": "x",
+            "label": "Date",
+            "format": "%Y"
+          },
+          {
+            "key": "q50",
+            "label": "Average",
+            "format": ".2f"
+          },
+          {
+            "key": "q25",
+            "label": "25th percentile",
+            "format": ".2f"
+          },
+          {
+            "key": "q75",
+            "label": "75th percentile",
+            "format": ".2f"
+          }
+        ]
+      }
+    }
+]
 };
 /* eslint-enable */
 


### PR DESCRIPTION
This PR adds a tooltip to the widgets generated from the chart of the NexGDDP tool. Note that this tooltip is not (yet) shown in the tool but only in places where we use the `VegaChart` component from RW (for example in My Prep).

You can test this PR by creating a widget from the NexGDDP tool and going to My Prep then. You won't be able to see the tooltip if https://github.com/resource-watch/prep-manager/pull/31 is not merged.