### PR TITLE
NexGDDP: Add a help text below the map

### DIFF
--- a/app/scripts/components/nexgddp-tool/NexGDDPTool.jsx
+++ b/app/scripts/components/nexgddp-tool/NexGDDPTool.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import Icon from 'components/ui/Icon';
 import ScenarioSelect from './scenario-select';
 import DateRangeSelect from './date-range-select/DateRangeSelect';
 import TempResolutionSelect from './temp-resolution-select';
@@ -105,6 +106,12 @@ class NexGDDPTool extends React.PureComponent {
             </div>
           </div>
         </div>
+
+        {!marker && (
+          <div className="help-text">
+            Click on the <span aria-label="Marker icon on the map"><Icon name="icon-marker" /></span> icon or search for a place to analyze in detail.
+          </div>
+        )}
 
         {marker && indicatorDataset && (
           <div className="chart">

--- a/app/scripts/components/nexgddp-tool/style.scss
+++ b/app/scripts/components/nexgddp-tool/style.scss
@@ -31,4 +31,8 @@
     border-radius: 100%;
     box-shadow: 0 7px 15px 0 rgba(0, 0, 0, .15);
   }
+
+  > .help-text {
+    font-weight: $font-weight-bold;
+  }
 }


### PR DESCRIPTION
This PR adds a small sentence below the map of the NexGDDP tool to indicate the user to add a marker to analyte a specific place.

<p align="center">
<img width="1128" alt="NexGDDP tool with a sentence below the map inviting the user to click on an icon to add a marker and analyse that area" src="https://user-images.githubusercontent.com/6073968/34985761-21e27f0e-faad-11e7-87b2-b5ae7100b620.png">
</p>

[Pivotal task](https://www.pivotaltracker.com/story/show/154278363)
