### PR TITLE
NexGDDP: change the default date range

### DIFF
--- a/app/scripts/actions/nexgddptool.js
+++ b/app/scripts/actions/nexgddptool.js
@@ -297,9 +297,13 @@ export function setTempResolutionSelection(selection, changeUrl = true) {
 
     // We need to reset the date selectors too
     const range1Options = getState().nexgddptool.range1.options;
+    const currentYear = (new Date()).getUTCFullYear();
+    const selectedOption = range1Options[selection.value]
+      .find(option => currentYear > option.label.split('-')[0]
+        && currentYear < option.label.split('-')[1]);
     dispatch({
       type: NEXGDDP_SET_RANGE1_SELECTION,
-      payload: range1Options[selection.value][0]
+      payload: selectedOption || range1Options[selection.value][0]
     });
 
     dispatch({
@@ -503,7 +507,10 @@ export function setDefaultState() {
     if (!store.nexgddptool.range1.selection && Object.keys(store.nexgddptool.range1.options).length && store.nexgddptool.tempResolution.options.length) {
       const options = store.nexgddptool.range1.options[tempResolutionValue];
       if (options && options.length) {
-        const range1Promise = dispatch(setRange1Selection(options[0]));
+        const currentYear = (new Date()).getUTCFullYear();
+        const selectedOption = options.find(option => currentYear > option.label.split('-')[0]
+          && currentYear < option.label.split('-')[1]);
+        const range1Promise = dispatch(setRange1Selection(selectedOption || options[0]));
         promises.push(range1Promise);
       }
     }

--- a/app/scripts/actions/nexgddptool.js
+++ b/app/scripts/actions/nexgddptool.js
@@ -508,8 +508,8 @@ export function setDefaultState() {
       const options = store.nexgddptool.range1.options[tempResolutionValue];
       if (options && options.length) {
         const currentYear = (new Date()).getUTCFullYear();
-        const selectedOption = options.find(option => currentYear > option.label.split('-')[0]
-          && currentYear < option.label.split('-')[1]);
+        const selectedOption = options.find(option => currentYear >= option.label.split('-')[0]
+          && currentYear <= option.label.split('-')[1]);
         const range1Promise = dispatch(setRange1Selection(selectedOption || options[0]));
         promises.push(range1Promise);
       }

--- a/app/scripts/actions/nexgddptool.js
+++ b/app/scripts/actions/nexgddptool.js
@@ -299,8 +299,8 @@ export function setTempResolutionSelection(selection, changeUrl = true) {
     const range1Options = getState().nexgddptool.range1.options;
     const currentYear = (new Date()).getUTCFullYear();
     const selectedOption = range1Options[selection.value]
-      .find(option => currentYear > option.label.split('-')[0]
-        && currentYear < option.label.split('-')[1]);
+      .find(option => currentYear >= option.label.split('-')[0]
+        && currentYear <= option.label.split('-')[1]);
     dispatch({
       type: NEXGDDP_SET_RANGE1_SELECTION,
       payload: selectedOption || range1Options[selection.value][0]


### PR DESCRIPTION
This PR changes the default date range of the NexGDDP tool. Previously the first one available, it is now the one that includes today's date.

To test, go to `/dataset/tasmax_rcp45_decadal` and you should see "2011-2020" as the selected range.

[Pivotal task](https://www.pivotaltracker.com/story/show/154661044)