### PR TITLE
Fixed a bug that prevented showing two Carto layers at once

### DIFF
--- a/app/scripts/components/map-vis/layer-manager/carto-layer.js
+++ b/app/scripts/components/map-vis/layer-manager/carto-layer.js
@@ -18,8 +18,6 @@ function makeCancellableRequest(url, bodyStringified) {
   });
 }
 
-let postRequest;
-
 export default (leafletMap, layerSpec) => {
   const {
     layerConfig,
@@ -37,8 +35,7 @@ export default (leafletMap, layerSpec) => {
   const url = `https://${layerConfig.account}.carto.com/api/v1/map`;
 
   return new Promise((resolve, reject, onCancel) => {
-    if (postRequest) postRequest.cancel();
-    postRequest = makeCancellableRequest(url, bodyStringified);
+    const postRequest = makeCancellableRequest(url, bodyStringified);
     postRequest
       .then((res) => {
         if (res.status !== 200) reject(res);


### PR DESCRIPTION
This PR fixes a bug that prevented the Explore map to show two Carto layers at once.

Essentially, a few lines of code were written to make sure that if we update an existing layer, the previous request would be cancelled. In practice, since the instance of the map component is maintained throughout the interaction with the map, the lines would permit loading only one Carto layer at a time, rejecting a `Promise.all` that would be later in charge of displaying those layers.

In order to test the changes, go to this page: `/explore?activeDatasets=011a2a6a-3bd5-4a8a-9dda-57775db4e604|1|true|0&activeDatasets=c53a195f-d5f0-4acc-b1be-b773420a6606|1|true|1&basemap=default&boundaries=false&filterQuery=&labels=none&lat=48.3416461723746&lng=-123.92578125000001&location=global&minZoom=3&tab=core_datasets&zoom=3`. You should be able to see the two layers.

[Pivotal task](https://www.pivotaltracker.com/story/show/154374419)