### PR TITLE
Correctly sort the filters of Explore

### DIFF
--- a/app/scripts/services/dataset-filter-service.js
+++ b/app/scripts/services/dataset-filter-service.js
@@ -6,18 +6,34 @@ import DATATYPES from 'pages/explore/explore-dataset-filters/data/data-types.jso
 import PERIODS from 'pages/explore/explore-dataset-filters/data/periods.json';
 
 
+/**
+ * Recursively sort a tree of collections
+ * @param {object[]} collection Collection to sort
+ * @param {string} attribute Attribute to sort with
+ */
+const recursivelySortBy = (collection, attribute) => sortBy(collection, attribute).map((subCollection) => {
+  const res = Object.assign({}, subCollection);
+
+  if (subCollection.children) {
+    // eslint-disable-next-line no-param-reassign
+    res.children = sortBy(subCollection.children, attribute);
+  }
+
+  return res;
+});
+
 class DatasetFilterService {
   static getTopics() {
-    return new Promise(resolve => resolve({ topics: sortBy(TOPICS, 'label') }));
+    return new Promise(resolve => resolve({ topics: recursivelySortBy(TOPICS, 'label') }));
   }
   static getGeographies() {
-    return new Promise(resolve => resolve({ geographies: sortBy(GEOGRAPHIES, 'label') }));
+    return new Promise(resolve => resolve({ geographies: recursivelySortBy(GEOGRAPHIES, 'label') }));
   }
   static getDataTypes() {
-    return new Promise(resolve => resolve({ dataTypes: sortBy(DATATYPES, 'label') }));
+    return new Promise(resolve => resolve({ dataTypes: recursivelySortBy(DATATYPES, 'label') }));
   }
   static getPeriods() {
-    return new Promise(resolve => resolve({ periods: sortBy(PERIODS, 'label') }));
+    return new Promise(resolve => resolve({ periods: recursivelySortBy(PERIODS, 'label') }));
   }
 }
 


### PR DESCRIPTION
This PR recursively sorts the filters of the Explore Page.

To test it:
1. Open the Explore page
2. Click "All datasets"
3. Click "Filter results"
4. Click on any of the filters (for example, "Topics") and you'll see the whole tree is sorted instead of just the first level

[Pivotal task](https://www.pivotaltracker.com/story/show/154726972)