### PR TITLE
NexGDDP: regressions that broke sharing the map and graph

### DIFF
--- a/app/scripts/components/Tooltip/ShareNexgddpChartTooltip.jsx
+++ b/app/scripts/components/Tooltip/ShareNexgddpChartTooltip.jsx
@@ -35,7 +35,7 @@ class ShareNexgddpChartTooltip extends React.Component {
 
   onClickSave() {
     this.props.toggleTooltip(false);
-    this.props.toggleEditorModal(true, {
+    this.props.toggleModal(true, {
       children: SaveWidgetModal,
       childrenProps: {
         datasetId: this.props.datasetId,
@@ -74,7 +74,7 @@ ShareNexgddpChartTooltip.propTypes = {
   toggleTooltip: PropTypes.func,
   getWidgetConfig: PropTypes.func,
   onClickCheckWidgets: PropTypes.func,
-  toggleEditorModal: PropTypes.func,
+  toggleModal: PropTypes.func,
   setOpen: PropTypes.func,
   setLinks: PropTypes.func
 };

--- a/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
@@ -245,6 +245,7 @@ class CompareMap extends React.PureComponent {
                 }}
                 setOpen={this.props.setOpen}
                 setLinks={this.props.setLinks}
+                setAnalytics={shareModalActions.setAnalytics}
               />
             </Control>
           }

--- a/app/scripts/components/nexgddp-tool/tool-map/DifferenceMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/DifferenceMap.jsx
@@ -134,6 +134,7 @@ class DifferenceMap extends React.PureComponent {
                 }}
                 setOpen={this.props.setOpen}
                 setLinks={this.props.setLinks}
+                setAnalytics={shareModalActions.setAnalytics}
               />
             </Control>
           }

--- a/app/scripts/components/nexgddp-tool/tool-map/SimpleMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/SimpleMap.jsx
@@ -138,6 +138,7 @@ class SimpleMap extends React.PureComponent {
                 }}
                 setOpen={this.props.setOpen}
                 setLinks={this.props.setLinks}
+                setAnalytics={shareModalActions.setAnalytics}
               />
             </Control>
           }

--- a/app/scripts/components/nexgddp-tool/tool-map/ToggleMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/ToggleMap.jsx
@@ -145,6 +145,7 @@ class ToggleMap extends React.PureComponent {
               setBasemap={this.props.setBasemap}
               setLabels={this.props.setLabels}
               setBoundaries={this.props.setBoundaries}
+              setAnalytics={shareModalActions.setAnalytics}
             />
           </Control>
 

--- a/app/scripts/components/share-control/share-control-component.jsx
+++ b/app/scripts/components/share-control/share-control-component.jsx
@@ -12,13 +12,17 @@ class ShareControl extends Component {
     const { open } = this.props;
     event.preventDefault();
     this.props.setOpen(!open);
-    this.props.setAnalytics({
-      category: 'Explore data',
-      action: 'Share a map'
-    });
     this.props.setLinks(this.props.links);
 
-    logEvent('Explore data', 'Share a map', 'Opens infowindow');
+    // Only for Explore
+    if (this.props.analytics) {
+      const { category, action } = this.props.analytics;
+      this.props.setAnalytics({
+        category,
+        action
+      });
+      logEvent(category, action, 'Opens infowindow');
+    }
   }
 
   render() {
@@ -46,7 +50,15 @@ ShareControl.propTypes = {
   links: PropTypes.object,
   setOpen: PropTypes.func,
   setLinks: PropTypes.func,
-  setAnalytics: PropTypes.func
+  setAnalytics: PropTypes.func.isRequired,
+  /**
+   * Define the category and action for the analytics
+   * event of the share modal
+   */
+  analytics: PropTypes.shape({
+    category: PropTypes.string,
+    action: PropTypes.string
+  })
 };
 
 export default ShareControl;

--- a/app/scripts/pages/explore/explore-map/explore-map-component.jsx
+++ b/app/scripts/pages/explore/explore-map/explore-map-component.jsx
@@ -65,6 +65,10 @@ class ExploreMap extends PureComponent {
               }}
               setOpen={this.props.setOpen}
               setLinks={this.props.setLinks}
+              analytics={{
+                category: 'Explore data',
+                action: 'Share a map'
+              }}
             />
           }
         </Map>


### PR DESCRIPTION
This PR fixes two regressions that broke the ability to share the map and graph of the NexGDDP tool.

Go to any NexGDDP dataset to test it.

[Pivotal task](https://www.pivotaltracker.com/story/show/154805635)