### PR TITLE
NexGDDP: tooltip for the graph

### DIFF
--- a/app/scripts/components/nexgddp-tool/tool-chart/style.scss
+++ b/app/scripts/components/nexgddp-tool/tool-chart/style.scss
@@ -31,4 +31,8 @@
       }
     }
   }
+
+  .c-we-chart {
+    height: 300px;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12813,9 +12813,9 @@
       }
     },
     "widget-editor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.1.1.tgz",
-      "integrity": "sha1-xvPC7IRQslNqM/cb8OqmEo/YLws=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.1.2.tgz",
+      "integrity": "sha1-pHXMSk6j9af0RiSmDtZUs5VHyMg=",
       "requires": {
         "autobind-decorator": "2.1.0",
         "babel-runtime": "6.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12813,9 +12813,9 @@
       }
     },
     "widget-editor": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.1.0.tgz",
-      "integrity": "sha1-Ga5WE3+wXge8EwEPEabaptSvsJ4=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.1.1.tgz",
+      "integrity": "sha1-xvPC7IRQslNqM/cb8OqmEo/YLws=",
       "requires": {
         "autobind-decorator": "2.1.0",
         "babel-runtime": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "webpack-dev-middleware": "1.12.2",
     "webpack-merge": "4.1.0",
     "whatwg-fetch": "2.0.3",
-    "widget-editor": "0.1.0"
+    "widget-editor": "0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "webpack-dev-middleware": "1.12.2",
     "webpack-merge": "4.1.0",
     "whatwg-fetch": "2.0.3",
-    "widget-editor": "0.1.1"
+    "widget-editor": "0.1.2"
   }
 }


### PR DESCRIPTION
This PR adds a tooltip to the NexGDDP graph.

Previously, [I've already added a tooltip](https://github.com/resource-watch/prep-app/pull/179) to the configuration of the Vega spec, but it was only supported by other renderers (in My Prep for example). This PR tweaks the tooltip according to some feedback from WRI (see Pivotal's task) but also uses the [editor's renderer](https://github.com/resource-watch/widget-editor/blob/develop/src/components/chart/VegaChart.js) for the NexGDDP chart so the tooltip can be seen there too.

~~**🚨 This PR can't be merged until v0.1.2 of the [editor](https://github.com/resource-watch/widget-editor) is released because the latest version contains bugs in the renderer.**~~

This PR updates the [widget-editor](https://github.com/resource-watch/widget-editor) to v0.1.2.

[Pivotal task](https://www.pivotaltracker.com/story/show/154409316)