### PR TITLE
NexGDDP: prevent the close button from overlapping the chart

### DIFF
--- a/app/scripts/components/nexgddp-tool/tool-chart/style.scss
+++ b/app/scripts/components/nexgddp-tool/tool-chart/style.scss
@@ -3,7 +3,7 @@
 .c-tool-timeseries-chart {
   position: relative;
   min-height: 100px; // Needed for the loader
-  padding-top: 20px;
+  padding-top: 40px;
   border: 2px solid $border-color;
   border-top: 0;
 


### PR DESCRIPTION
This PR prevents the close button from overlapping the text labels of the chart.

Before the fix:
<img width="256" alt="Yellow label is overlapped by the close button" src="https://user-images.githubusercontent.com/6073968/35854347-069d2916-0b28-11e8-9c54-81181037fee5.png">

After:
<img width="255" alt="Yellow label is under the close button" src="https://user-images.githubusercontent.com/6073968/35854285-dd2b892e-0b27-11e8-9f7f-a5d24eefa8ff.png">

[Comment on Pivotal](https://www.pivotaltracker.com/story/show/154409316/comments/185485944)