### PR TITLE
Gradient transparent legend

### DIFF
--- a/app/scripts/components/legend/legend-types/legend-gradient/LegendGradient.jsx
+++ b/app/scripts/components/legend/legend-types/legend-gradient/LegendGradient.jsx
@@ -3,11 +3,29 @@ import PropTypes from 'prop-types';
 import './legend-gradient.scss';
 
 export const LegendGradient = ({ legendSpec }) => {
-  const gradient = legendSpec.items.map(item => item.color);
+  const items = legendSpec.items.filter(item => item.color !== 'transparent');
+  const itemTransparent = legendSpec.items.find(item => item.color === 'transparent');
+  const gradient = items.map(item => item.color);
 
   return (
     <div className="c-legend-gradient">
-      <div className="icon-gradient" style={{ backgroundImage: `linear-gradient(to right, ${gradient.join(',')})` }} />
+      <div className="legend-gradient-icon">
+        {itemTransparent &&
+          <div
+            style={{
+              width: `${(1 / legendSpec.items.length) * 100}%`
+            }}
+            className="icon-gradient-transparent"
+          />
+        }
+        <div
+          className="icon-gradient"
+          style={{
+            width: `${(items.length / legendSpec.items.length) * 100}%`,
+            backgroundImage: `linear-gradient(to right, ${gradient.join(',')})`
+          }}
+        />
+      </div>
       <ul>
         {legendSpec.items.map(({ name, color, value }) => (
           <li key={`legend-gradient-item-${color}-${value}`}>

--- a/app/scripts/components/legend/legend-types/legend-gradient/legend-gradient.scss
+++ b/app/scripts/components/legend/legend-types/legend-gradient/legend-gradient.scss
@@ -1,9 +1,10 @@
 .c-legend-gradient {
   ul {
     display: flex;
-    margin: 0;
+    margin: 0 0 16px;
     padding: 0;
     list-style: none;
+    font-size: 12px;
   }
 
   li {
@@ -18,10 +19,12 @@
 
   .name {
     display: block;
-
     font-family: 'Helvetica Neue', Arial, sans-serif;
-    font-size: 12px;
     text-align: center;
+  }
+
+  .legend-gradient-icon {
+    display: flex;
   }
 
   .icon-gradient {
@@ -29,5 +32,18 @@
     height: 5px;
     margin-top: 10px;
     margin-bottom: 5px;
+  }
+
+  .icon-gradient-transparent {
+    display: block;
+    height: 5px;
+    margin-top: 10px;
+    margin-bottom: 5px;
+    background-image:
+      linear-gradient(45deg, rgba(black, .4) 25%, transparent 25%, transparent 75%, rgba(black, .4) 75%, rgba(black, .4)),
+      linear-gradient(45deg, rgba(black, .4) 25%, transparent 25%, transparent 75%, rgba(black, .4) 75%, rgba(black, .4));
+
+    background-size: 6px 6px;
+    background-position: 0 0, 3px 3px
   }
 }

--- a/app/scripts/components/legend/legend-types/legend-gradient/legend-gradient.scss
+++ b/app/scripts/components/legend/legend-types/legend-gradient/legend-gradient.scss
@@ -43,7 +43,7 @@
       linear-gradient(45deg, rgba(black, .4) 25%, transparent 25%, transparent 75%, rgba(black, .4) 75%, rgba(black, .4)),
       linear-gradient(45deg, rgba(black, .4) 25%, transparent 25%, transparent 75%, rgba(black, .4) 75%, rgba(black, .4));
 
-    background-size: 6px 6px;
-    background-position: 0 0, 3px 3px
+    background-size: 4px 4px;
+    background-position: 0 0, 2px 2px
   }
 }


### PR DESCRIPTION
This PR adds:
- Transparent step to gradient legends.

### Pivotal ###
https://www.pivotaltracker.com/story/show/154842270

### Testing instructions ###
http://localhost:3000/explore?activeDatasets=aaadd6c3-93ea-44bc-ba8b-7af3f40d39e1%7C1%7Ctrue%7C1&activeDatasets=df0aabe8-0ef2-4a81-bdba-c6fc6767fde9%7C1%7Ctrue%7C0&basemap=default&bbox&boundaries=true&filterQuery=&labels=none&lat=50.12057809796008&lng=8.173828125000002&location=global&minZoom=3&tab=core_datasets&zoom=5