### PR TITLE
Embed widget support

### DIFF
--- a/app/scripts/components/Modal/CreateEmbedWidget.jsx
+++ b/app/scripts/components/Modal/CreateEmbedWidget.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getConfig, WidgetService } from 'widget-editor';
+
+// Components
+import LoadingSpinner from 'components/Loading/LoadingSpinner';
+
+class CreateEmbedWidget extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: false,
+      error: false,
+      saved: false
+    };
+
+    this.onCreateWidget = this.onCreateWidget.bind(this);
+  }
+
+
+  /**
+   * Event handler executed when the user creates an
+   * embed widget
+   * @param {Event} e Event
+   */
+  onCreateWidget(e) {
+    e.preventDefault();
+
+    const { url, dataset, links } = this.props;
+    const form = e.target;
+    const formData = new FormData(form);
+    const title = formData.get('title');
+    const description = formData.get('description');
+
+    if (!title.length) {
+      this.setState({ error: 'You need to give your widget a title.' });
+      return;
+    }
+
+    this.setState({ loading: true, error: false });
+
+    const widgetConfig = {
+      type: 'embed',
+      url
+    };
+
+    const widget = {
+      name: title,
+      description,
+      widgetConfig
+    };
+
+    WidgetService.saveUserWidget(widget, dataset, getConfig().userToken)
+      .then((res) => {
+        if (!links.length) return null;
+
+        const { id } = res.data;
+
+        return fetch(`${getConfig().url}/dataset/${dataset}/widget/${id}/metadata`, {
+          method: 'POST',
+          body: JSON.stringify({
+            application: getConfig().applications,
+            language: 'en',
+            info: { widgetLinks: links }
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${getConfig().userToken}`
+          }
+        });
+      })
+      .then(() => this.setState({ saved: true, error: false }))
+      .catch(() => this.setState({ saved: false, error: true }))
+      .then(() => this.setState({ loading: false }));
+  }
+
+  render() {
+    const { loading, error, saved } = this.state;
+
+    return (
+      <div className="c-create-embed-widget">
+        { loading && <LoadingSpinner inner /> }
+        { !loading && error && (
+          <p className="error">{'Sorry, the widget couldn\'t be created. Try again in a few minutes.'}</p>
+        )}
+        { !saved && (
+          <form onSubmit={this.onCreateWidget}>
+            <label htmlFor="share-modal-widget-title">Widget title</label>
+            <input type="text" id="share-modal-widget-title" name="title" placeholder="Widget title" required />
+            <label htmlFor="share-modal-description">Description</label>
+            <textarea id="share-modal-description" name="description" placeholder="Description" />
+            <button type="submit" className="c-button -border -fill">Create</button>
+          </form>
+        )}
+        { saved && (
+          <div>
+            <p>The widget has been saved!</p>
+            <a href="/myprep/widgets/my_widgets" className="c-button -border -fill">Check your widgets</a>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+CreateEmbedWidget.propTypes = {
+  /**
+   * URL of the page to embed in the widget
+   */
+  url: PropTypes.string.isRequired,
+  /**
+   * ID of the dataset attached to the widget
+   */
+  dataset: PropTypes.string.isRequired,
+  /**
+   * Links to add to the metadata, for example,
+   * additional datasets
+   */
+  links: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    link: PropTypes.string.isRequired
+  }))
+};
+
+CreateEmbedWidget.defaultProps = {
+  links: []
+};
+
+export default CreateEmbedWidget;

--- a/app/scripts/components/Tooltip/ShareNexgddpChartTooltip.jsx
+++ b/app/scripts/components/Tooltip/ShareNexgddpChartTooltip.jsx
@@ -48,7 +48,6 @@ class ShareNexgddpChartTooltip extends React.Component {
   onClickShare() {
     const { open, datasetSlug } = this.props;
     const { origin, search } = window.location;
-    event.preventDefault();
     this.props.setOpen(!open);
     this.props.setLinks({
       embed: `${origin}/embed/nexgddp/${datasetSlug}${search}&render=chart`

--- a/app/scripts/components/Tooltip/ShareNexgddpTooltip.jsx
+++ b/app/scripts/components/Tooltip/ShareNexgddpTooltip.jsx
@@ -9,7 +9,7 @@ import * as shareModalActions from 'components/share-modal/share-modal-actions';
 // Redux
 import { toggleTooltip } from 'actions/tooltip';
 
-class ShareNexgddpChartTooltip extends React.Component {
+class ShareNexgddpTooltip extends React.Component {
   constructor(props) {
     super(props);
     this.onClickOutside = this.onClickOutside.bind(this);
@@ -46,11 +46,11 @@ class ShareNexgddpChartTooltip extends React.Component {
   }
 
   onClickShare() {
-    const { open, datasetSlug } = this.props;
+    const { open, datasetSlug, render } = this.props;
     const { origin, search } = window.location;
     this.props.setOpen(!open);
     this.props.setLinks({
-      embed: `${origin}/embed/nexgddp/${datasetSlug}${search}&render=chart`
+      embed: `${origin}/embed/nexgddp/${datasetSlug}${search}&render=${render}`
     });
   }
 
@@ -66,19 +66,23 @@ class ShareNexgddpChartTooltip extends React.Component {
   }
 }
 
-ShareNexgddpChartTooltip.propTypes = {
+ShareNexgddpTooltip.propTypes = {
   open: PropTypes.bool,
   datasetId: PropTypes.string,
   datasetSlug: PropTypes.string,
   toggleTooltip: PropTypes.func,
   getWidgetConfig: PropTypes.func,
+  /**
+   * Either to embed the chart or the map
+   */
+  render: PropTypes.oneOf(['chart', 'map']).isRequired,
   onClickCheckWidgets: PropTypes.func,
   toggleModal: PropTypes.func,
   setOpen: PropTypes.func,
   setLinks: PropTypes.func
 };
 
-ShareNexgddpChartTooltip.defaultProps = {
+ShareNexgddpTooltip.defaultProps = {
   onClickCheckWidgets: () => {
     window.location = '/myprep/widgets/my_widgets';
   }
@@ -95,4 +99,4 @@ const mapDispatchToProps = {
   ...shareModalActions
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ShareNexgddpChartTooltip);
+export default connect(mapStateToProps, mapDispatchToProps)(ShareNexgddpTooltip);

--- a/app/scripts/components/nexgddp-tool/tool-chart/TimeseriesChart.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-chart/TimeseriesChart.jsx
@@ -13,7 +13,7 @@ import { toggleTooltip } from 'actions/tooltip';
 // Component
 import Icon from 'components/ui/Icon';
 import Spinner from 'components/Loading/LoadingSpinner';
-import ShareNexgddpChartTooltip from 'components/Tooltip/ShareNexgddpChartTooltip';
+import ShareNexgddpTooltip from 'components/Tooltip/ShareNexgddpTooltip';
 
 import './style.scss';
 
@@ -488,8 +488,9 @@ class TimeseriesChart extends React.Component {
         y: window.scrollY + e.clientY
       },
       direction: 'bottom',
-      children: ShareNexgddpChartTooltip,
+      children: ShareNexgddpTooltip,
       childrenProps: {
+        render: 'chart',
         getWidgetConfig: () => TimeseriesChart.generateVegaSpec(this.props)
       }
     });

--- a/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
 import { connect } from 'react-redux';
-
 import L from 'leaflet';
 import { Map, TileLayer, ZoomControl, Marker } from 'react-leaflet';
 import Control from 'react-leaflet-control';
@@ -13,14 +11,12 @@ import 'lib/leaflet-side-by-side/leaflet-side-by-side';
 import { getLayers, getRawLayers } from 'selectors/nexgddptool';
 import { setMarkerPosition, setMapZoom, setMapCenter, setBasemap, setBoundaries, setLabels, setWater, setMarkerMode } from 'actions/nexgddptool';
 import * as shareModalActions from 'components/share-modal/share-modal-actions';
+import { toggleTooltip } from 'actions/tooltip';
 
 // Components
 import Legend from 'components/legend/index';
 import BasemapControl from 'components/basemap-control';
-import ShareControl from 'components/share-control/share-control-component';
 import { basemapsSpec, labelsSpec, boundariesSpec, waterSpec } from 'components/basemap-control/basemap-control-constants';
-
-// Components
 import Icon from 'components/ui/Icon';
 
 const mapDefaultOptions = {
@@ -124,6 +120,37 @@ class CompareMap extends React.PureComponent {
     }
   }
 
+  /**
+   * Event handler executed when the user clicks the share button
+   * @param {MouseEvent} e Event object
+   */
+  onClickShare(e) {
+    // Prevent the tooltip from auto-closing
+    e.stopPropagation();
+
+    const { dataset } = this.props;
+    const { origin, search } = window.location;
+
+    this.props.toggleTooltip(true, {
+      follow: false,
+      position: {
+        x: window.scrollX + e.clientX,
+        y: window.scrollY + e.clientY
+      },
+      direction: 'bottom',
+      children: ShareNexgddpTooltip,
+      childrenProps: {
+        render: 'map',
+        getWidgetConfig: () => new Promise((resolve) => {
+          resolve({
+            type: 'embed',
+            url: `${origin}/embed/nexgddp/${dataset.id}${search}&render=map`
+          });
+        })
+      }
+    });
+  }
+
   setMarkerMode() {
     const { markerMode } = this.props;
     this.props.setMarkerMode(!markerMode);
@@ -163,7 +190,7 @@ class CompareMap extends React.PureComponent {
   }
 
   render() {
-    const { dataset, embed, map, marker, markerMode, range1Selection, range2Selection, rawLayers } = this.props;
+    const { embed, map, marker, markerMode, range1Selection, range2Selection, rawLayers } = this.props;
 
     // It will change center of map on marker location
     const mapOptions = Object.assign({}, mapDefaultOptions, {
@@ -178,8 +205,6 @@ class CompareMap extends React.PureComponent {
     const makerControlClassNames = classnames({
       '-active': markerMode
     });
-
-    const { origin, search } = window.location;
 
     return (
       <div className="c-tool-map">
@@ -243,15 +268,13 @@ class CompareMap extends React.PureComponent {
 
           {!embed &&
             <Control position="bottomright">
-              <ShareControl
-                open={this.props.open}
-                links={{
-                  embed: `${origin}/embed/nexgddp/${(dataset || {}).slug}${search}&render=map`
-                }}
-                setOpen={this.props.setOpen}
-                setLinks={this.props.setLinks}
-                setAnalytics={shareModalActions.setAnalytics}
-              />
+              <button
+                type="button"
+                className="c-button-map"
+                onClick={e => this.onClickShare(e)}
+              >
+                <Icon name="icon-share" className="-small" />
+              </button>
             </Control>
           }
         </Map>
@@ -295,7 +318,8 @@ CompareMap.propTypes = {
   setWater: PropTypes.func,
   setBoundaries: PropTypes.func,
   setOpen: PropTypes.func,
-  setLinks: PropTypes.func
+  setLinks: PropTypes.func,
+  toggleTooltip: PropTypes.func
 };
 
 const mapStateToProps = state => ({
@@ -319,7 +343,8 @@ const mapDispatchToProps = {
   setLabels,
   setWater,
   setBoundaries,
-  ...shareModalActions
+  ...shareModalActions,
+  toggleTooltip
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CompareMap);

--- a/app/scripts/components/nexgddp-tool/tool-map/DifferenceMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/DifferenceMap.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
 import { connect } from 'react-redux';
-
 import L from 'leaflet';
 import { Map, TileLayer, ZoomControl, Marker } from 'react-leaflet';
 import Control from 'react-leaflet-control';
@@ -12,14 +10,15 @@ import Control from 'react-leaflet-control';
 import { getLayers, getRawLayers } from 'selectors/nexgddptool';
 import { setMarkerPosition, setMapZoom, setMapCenter, setBasemap, setBoundaries, setLabels, setWater, setMarkerMode } from 'actions/nexgddptool';
 import * as shareModalActions from 'components/share-modal/share-modal-actions';
+import { toggleTooltip } from 'actions/tooltip';
 
 // Components
 import Legend from 'components/legend/index';
 import BasemapControl from 'components/basemap-control';
-import ShareControl from 'components/share-control/share-control-component';
 import { basemapsSpec, labelsSpec, boundariesSpec, waterSpec } from 'components/basemap-control/basemap-control-constants';
-
 import Icon from 'components/ui/Icon';
+import ShareNexgddpTooltip from 'components/Tooltip/ShareNexgddpTooltip';
+
 
 const mapDefaultOptions = {
   center: [20, -30],
@@ -46,6 +45,37 @@ class DifferenceMap extends React.PureComponent {
     }
   }
 
+  /**
+   * Event handler executed when the user clicks the share button
+   * @param {MouseEvent} e Event object
+   */
+  onClickShare(e) {
+    // Prevent the tooltip from auto-closing
+    e.stopPropagation();
+
+    const { dataset } = this.props;
+    const { origin, search } = window.location;
+
+    this.props.toggleTooltip(true, {
+      follow: false,
+      position: {
+        x: window.scrollX + e.clientX,
+        y: window.scrollY + e.clientY
+      },
+      direction: 'bottom',
+      children: ShareNexgddpTooltip,
+      childrenProps: {
+        render: 'map',
+        getWidgetConfig: () => new Promise((resolve) => {
+          resolve({
+            type: 'embed',
+            url: `${origin}/embed/nexgddp/${dataset.id}${search}&render=map`
+          });
+        })
+      }
+    });
+  }
+
   setMarkerMode() {
     const { markerMode } = this.props;
     this.props.setMarkerMode(!markerMode);
@@ -61,7 +91,7 @@ class DifferenceMap extends React.PureComponent {
   }
 
   render() {
-    const { dataset, embed, map, marker, markerMode, layers, rawLayers } = this.props;
+    const { embed, map, marker, markerMode, layers, rawLayers } = this.props;
 
     // It will change center of map on marker location
     const mapOptions = Object.assign({}, mapDefaultOptions, {
@@ -78,8 +108,6 @@ class DifferenceMap extends React.PureComponent {
     const makerControlClassNames = classnames({
       '-active': markerMode
     });
-
-    const { origin, search } = window.location;
 
     return (
       <div className="c-tool-map">
@@ -130,15 +158,13 @@ class DifferenceMap extends React.PureComponent {
 
           {!embed &&
             <Control position="bottomright">
-              <ShareControl
-                open={this.props.open}
-                links={{
-                  embed: `${origin}/embed/nexgddp/${(dataset || {}).slug}${search}&render=map`
-                }}
-                setOpen={this.props.setOpen}
-                setLinks={this.props.setLinks}
-                setAnalytics={shareModalActions.setAnalytics}
-              />
+              <button
+                type="button"
+                className="c-button-map"
+                onClick={e => this.onClickShare(e)}
+              >
+                <Icon name="icon-share" className="-small" />
+              </button>
             </Control>
           }
 
@@ -177,7 +203,8 @@ DifferenceMap.propTypes = {
   setWater: PropTypes.func,
   setBoundaries: PropTypes.func,
   setOpen: PropTypes.func,
-  setLinks: PropTypes.func
+  setLinks: PropTypes.func,
+  toggleTooltip: PropTypes.func
 };
 
 const mapStateToProps = state => ({
@@ -199,7 +226,8 @@ const mapDispatchToProps = {
   setLabels,
   setWater,
   setBoundaries,
-  ...shareModalActions
+  ...shareModalActions,
+  toggleTooltip
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(DifferenceMap);

--- a/app/scripts/components/share-modal/share-modal-component.jsx
+++ b/app/scripts/components/share-modal/share-modal-component.jsx
@@ -3,24 +3,64 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 // Components
-import Modal from '../Modal/Modal';
-import ShareUrl from '../../containers/Modal/ShareUrl';
+import Modal from 'components/Modal/Modal';
+import ShareUrl from 'containers/Modal/ShareUrl';
+import CreateEmbedWidget from 'containers/Modal/CreateEmbedWidget';
 
 class ShareModalComponent extends PureComponent {
   componentWillMount() {
-    const { link, embed } = this.props.links;
-
-    if (!link && embed) {
-      this.props.setTab('embed');
+    const keys = Object.keys(this.props.links);
+    if (keys.length) {
+      this.props.setTab(keys[0]);
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { link, embed } = nextProps.links;
+  /**
+   * Return the content of the current tab
+   */
+  getContent() {
+    const { tab, links } = this.props;
+    let content = null;
 
-    if (!link && embed) {
-      this.props.setTab('embed');
+    if (tab === 'link') {
+      content = (
+        <div className="embed-content">
+          <h3>Share this page</h3>
+          <p>Click and paste link in email or IM</p>
+          <ShareUrl
+            url={links[tab]}
+            iframe={false}
+            analytics={this.props.analytics}
+          />
+        </div>
+      );
+    } else if (tab === 'embed') {
+      content = (
+        <div className="embed-content">
+          <h3>Share into my web</h3>
+          <p>You may include this content on your webpage. To do this, copy the following html code and insert it into the source code of your page:</p>
+          <ShareUrl
+            url={links[tab]}
+            iframe
+            analytics={this.props.analytics}
+          />
+        </div>
+      );
+    } else if (tab === 'widget') {
+      content = (
+        <div className="embed-content">
+          <h3>Create a widget</h3>
+          <p>{'Give your widget a name and description and you\'re ready.'}</p>
+          <CreateEmbedWidget
+            url={links[tab].url}
+            dataset={links[tab].dataset}
+            links={links[tab].widgetLinks || []}
+          />
+        </div>
+      );
     }
+
+    return content;
   }
 
   navbar() {
@@ -48,7 +88,7 @@ class ShareModalComponent extends PureComponent {
   }
 
   render() {
-    const { open, links, tab } = this.props;
+    const { open } = this.props;
 
     return (
       <Modal
@@ -58,28 +98,7 @@ class ShareModalComponent extends PureComponent {
         navbar={() => this.navbar()}
       >
         <div className="content">
-          <div className="embed-content">
-
-            <h3>
-              {tab === 'embed' ?
-                'Share into my web' :
-                'Share this page'
-              }
-            </h3>
-
-            <p>
-              {tab === 'embed' ?
-                'You may include this content on your webpage. To do this, copy the following html code and insert it into the source code of your page:' :
-                'Click and paste link in email or IM'
-              }
-            </p>
-
-            <ShareUrl
-              url={links[tab]}
-              iframe={tab === 'embed'}
-              analytics={this.props.analytics}
-            />
-          </div>
+          {this.getContent()}
         </div>
       </Modal>
     );

--- a/app/scripts/containers/Modal/CreateEmbedWidget.js
+++ b/app/scripts/containers/Modal/CreateEmbedWidget.js
@@ -1,0 +1,8 @@
+import { connect } from 'react-redux';
+import CreateEmbedWidget from 'components/Modal/CreateEmbedWidget';
+
+const mapStateToProps = () => ({});
+
+const mapDispatchToProps = () => ({});
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateEmbedWidget);

--- a/app/scripts/pages/explore/explore-map/explore-map-component.jsx
+++ b/app/scripts/pages/explore/explore-map/explore-map-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Map from 'components/map-vis';
 import classnames from 'classnames';
+import { getConfig } from 'widget-editor';
 import BasemapControl from 'components/basemap-control';
 import LegendControl from 'components/legend/legend-control';
 import ShareControl from 'components/share-control';
@@ -62,14 +63,28 @@ class ExploreMap extends PureComponent {
           />
 
           {!embed &&
-
             <ShareControl
               className="-absolute" // pfff....
               open={this.props.open}
-              links={{
-                link: window.location.href,
-                embed: `${origin}/embed/explore/${search}`
-              }}
+              links={Object.assign(
+                {
+                  link: window.location.href,
+                  embed: `${origin}/embed/explore/${search}`
+                },
+                activeLayers.length && getConfig().userToken
+                  ? {
+                    widget: {
+                      url: `${origin}/embed/explore/${search}`,
+                      dataset: activeLayers[0].dataset,
+                      widgetLinks: activeLayers.slice(1)
+                        .map(d => ({
+                          name: d.name,
+                          link: `${origin}/dataset/${d.dataset}`
+                        }))
+                    }
+                  }
+                  : {}
+              )}
               setOpen={this.props.setOpen}
               setLinks={this.props.setLinks}
               analytics={{

--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -45,6 +45,7 @@
   "components/widget-editor",
   "components/share-nexgddp-chart-tooltip",
   "components/markdown",
+  "components/create-embed-widget",
   "components/rc-tooltip";
 
   // Ui

--- a/app/styles/components/_create-embed-widget.scss
+++ b/app/styles/components/_create-embed-widget.scss
@@ -1,0 +1,35 @@
+.c-create-embed-widget {
+  label {
+    display: block;
+    font-weight: $font-weight-bold;
+
+    &:not(:first-of-type) {
+      margin-top: 15px;
+    }
+  }
+
+  input,
+  textarea {
+    display: block;
+    width: 100%;
+    margin-top: 5px;
+    font-size: $normal-font-size;
+    color: $main-color;
+    cursor: text;
+    border: 0;
+    border-bottom: 1px solid rgba($main-color, 0.3);
+  }
+
+  button {
+    margin-top: 15px;
+  }
+
+  a {
+    display: inline-block;
+    margin: 0;
+  }
+
+  .error {
+    color: red;
+  }
+}


### PR DESCRIPTION
This PR brings support for the embed widgets. The user can embed the map of the NexGDDP tool and the Explore one too.

To test:
- NexGGDP: go to any NexGDDP dataset and create a new widget from the map, it will appear in My Prep.
- Explore: create a map with two layers, click the share button and create the widget. It will also appear in My Prep.

From My Prep, you can get the embed link of the two widgets to test it. If you don't want to create widgets, you can see these two working (you need to run the two apps side-by-side locally):
- NexGDDP: `/embed/embed/a7437274-3089-4026-8aaf-5f0cf06763f1`
- Explore: `/embed/embed/eaf16acb-3ea1-4a3d-b749-4f622ac594aa`

Note tha you won't be able to test properly this PR before these two are merged: resource-watch/prep-manager#65 and resource-watch/prep-manager#66.

[Pivotal task 1](https://www.pivotaltracker.com/story/show/154279052)
[Pivotal task 2](https://www.pivotaltracker.com/story/show/153871674)