### PR TITLE
NexGDDP: bugs sharing the map

### DIFF
--- a/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
+++ b/app/scripts/components/nexgddp-tool/tool-map/CompareMap.jsx
@@ -18,6 +18,7 @@ import Legend from 'components/legend/index';
 import BasemapControl from 'components/basemap-control';
 import { basemapsSpec, labelsSpec, boundariesSpec, waterSpec } from 'components/basemap-control/basemap-control-constants';
 import Icon from 'components/ui/Icon';
+import ShareNexgddpTooltip from 'components/Tooltip/ShareNexgddpTooltip';
 
 const mapDefaultOptions = {
   center: [20, -30],

--- a/app/scripts/components/share-modal/share-modal-component.jsx
+++ b/app/scripts/components/share-modal/share-modal-component.jsx
@@ -15,6 +15,14 @@ class ShareModalComponent extends PureComponent {
     }
   }
 
+  componentWillReceiveProps(newProps) {
+    // We make sure that there's always an active tab
+    const keys = Object.keys(newProps.links);
+    if (keys.length) {
+      newProps.setTab(keys[0]);
+    }
+  }
+
   /**
    * Return the content of the current tab
    */


### PR DESCRIPTION
This PR addresses two bugs around sharing the map of the NexGDDP tool:
- the user wouldn't be able to share the compare map due to a missing import
- the user wouldn't be able to embed any map due to an issue with the share modal's default active tab

[Pivotal task](https://www.pivotaltracker.com/story/show/155198448)

_PS: In the task's comments, I've asked the client further questions regarding other bugs I couldn't replicate._