### PR TITLE
Explore: Fixes share modal tab navigation

### DIFF
--- a/app/scripts/components/share-modal/share-modal-component.jsx
+++ b/app/scripts/components/share-modal/share-modal-component.jsx
@@ -8,18 +8,11 @@ import ShareUrl from 'containers/Modal/ShareUrl';
 import CreateEmbedWidget from 'containers/Modal/CreateEmbedWidget';
 
 class ShareModalComponent extends PureComponent {
-  componentWillMount() {
+  componentDidMount() {
+    // We make sure that there's always an active tab
     const keys = Object.keys(this.props.links);
     if (keys.length) {
       this.props.setTab(keys[0]);
-    }
-  }
-
-  componentWillReceiveProps(newProps) {
-    // We make sure that there's always an active tab
-    const keys = Object.keys(newProps.links);
-    if (keys.length) {
-      newProps.setTab(keys[0]);
     }
   }
 


### PR DESCRIPTION
Towards https://www.pivotaltracker.com/story/show/155199374

Identified bug in explore share modal where unable to navigate through share modal tabs.