### PR TITLE
Explore:  Replace learn more icon

### DIFF
--- a/app/scripts/components/Explore/InfoSidebar.jsx
+++ b/app/scripts/components/Explore/InfoSidebar.jsx
@@ -137,7 +137,7 @@ class InfoSidebar extends React.Component {
       <nav className="info-actions">
         {downloadIcon}
         <Link to={`/dataset/${metadata.datasetSlug}`} className="info-tool more">
-          <Icon name="icon-share" className="-medium" />
+          <Icon name="icon-widgets" className="-medium" />
           Learn more
         </Link>
         {layerIcon}

--- a/app/scripts/components/dataset-card/dataset-card-component.jsx
+++ b/app/scripts/components/dataset-card/dataset-card-component.jsx
@@ -65,7 +65,7 @@ class DatasetCard extends PureComponent {
             </div>
             <div className="item-tools">
               <Link className="item-link" to={`/dataset/${dataset.slug}`}>
-                <Icon name="icon-share" />
+                <Icon name="icon-widgets" />
               </Link>
               {dataset.isSelected ?
                 <button key={'info-close'} onClick={() => this.onToggleInfo(dataset)} className="cancel">

--- a/app/scripts/pages/explore/explore-dataset-info/explore-dataset-info-component.jsx
+++ b/app/scripts/pages/explore/explore-dataset-info/explore-dataset-info-component.jsx
@@ -198,7 +198,7 @@ class DatasetInfo extends PureComponent {
                 className="info-tool more"
                 onClick={() => logEvent('Explore menu', 'Click through to dataset page', getTitle(dataset))}
               >
-                <Icon name="icon-share" className="-medium" />
+                <Icon name="icon-widgets" className="-medium" />
                 Learn more
               </LinkComponent>
 

--- a/static/icons/symbol-defs.hbs
+++ b/static/icons/symbol-defs.hbs
@@ -102,7 +102,7 @@
 <path d="M20.7 7.2h19.8v4.4h-19.8v-4.4zM20.7 20.4h15.4v4.4h-15.4v-4.4zM11.9 13.8c-2.43 0-4.4-1.97-4.4-4.4s1.97-4.4 4.4-4.4c2.43 0 4.4 1.97 4.4 4.4s-1.97 4.4-4.4 4.4zM11.9 27c-2.43 0-4.4-1.97-4.4-4.4s1.97-4.4 4.4-4.4c2.43 0 4.4 1.97 4.4 4.4s-1.97 4.4-4.4 4.4z"></path>
 </symbol>
 <symbol id="icon-widgets" viewBox="0 0 37 32">
-<title>widgets</title>
+<title>Learn more</title>
 <path d="M7.463 23v-14h6v14h-6zM15.463 23v-10h6v10h-6zM23.463 23v-20h6v20h-6zM3.463 29v-4h30v4h-30z"></path>
 </symbol>
 <symbol id="icon-check" viewBox="0 0 32 32">


### PR DESCRIPTION
Replace 'learn more' icon to:
![image](https://user-images.githubusercontent.com/8505382/37402588-7c1dbaae-278c-11e8-9b38-b2cdb5bed9a1.png)

*Note:* @davidsingal the alt text for the icon comes from the `<title>` of the svg. This has been changed, but perhaps not the most long term solution if icons are going to be downloaded from icomoon.