### PR TITLE
Use the dataset's metadata's title for the title of the NexGDDP embeds

### DIFF
--- a/app/scripts/pages/nexgddp-embed/nexgddp-embed-component.jsx
+++ b/app/scripts/pages/nexgddp-embed/nexgddp-embed-component.jsx
@@ -23,9 +23,13 @@ class NexGDDPEmbedPage extends PureComponent {
   render() {
     const { dataset, embed } = this.props;
 
+    const title = dataset.metadata && dataset.metadata.length && dataset.metadata[0].attributes.name
+      ? dataset.metadata[0].attributes.name
+      : dataset.name;
+
     return (
       <div className="-theme-2">
-        <h2>{dataset.name}</h2>
+        <h2>{title}</h2>
 
         {!isEmpty(dataset) &&
           <NexGDDPTool


### PR DESCRIPTION
Because the NexGDDP dataset are actually spread into several datasets in the API, when sharing an embed of a NexGDDP visualisation, we would display the name of a specific dataset instead of the one of the "group". By using the metadata's title, we avoid this problem.

[Pivotal task](https://www.pivotaltracker.com/story/show/155978598)