### PR TITLE
Fix a bug where the user couldn't login because the tooltip would close

### DIFF
--- a/app/scripts/components/user-options/user-options-style.scss
+++ b/app/scripts/components/user-options/user-options-style.scss
@@ -6,7 +6,7 @@
   position: absolute;
   width: auto;
   min-width: 160px;
-  margin-top: 22px;
+  margin-top: 11px;
   left: 50%;
   top: 50%;
   padding-top: 10px;

--- a/app/styles/components/_nav.scss
+++ b/app/styles/components/_nav.scss
@@ -126,6 +126,12 @@
           display: flex;
           justify-content: center;
           width: 50px;
+
+          .c-user {
+            display: flex;
+            align-items: center;
+            height: 100%;
+          }
         }
       }
     }

--- a/app/styles/layout/_header.scss
+++ b/app/styles/layout/_header.scss
@@ -73,7 +73,7 @@ $header-bg-color: $dark-slate-blue-2;
   .c-user-options {
     right: 0;
     left: auto;
-    transform: translate(-10px, 10px);
+    transform: translate(0, 17px);
 
     &:before {
       transform: translate(-33px, -100%);


### PR DESCRIPTION
This PR fixes a bug where the user would be unable to log in because the tooltip would close as soon as the cursor would leave the menu item. The area that triggers the `mouseover` and `mouseout` events has been increased and the tooltip has been brought closer to the menu item.

To test this PR, go to the About and Explore pages and see if you can click the options of the login tooltip.

[Pivotal task](https://www.pivotaltracker.com/story/show/158324867)