### PR TITLE
Fix a bug where the user would be unable to navigate away from Explore

### DIFF
--- a/app/scripts/pages/explore/explore-actions.js
+++ b/app/scripts/pages/explore/explore-actions.js
@@ -212,12 +212,15 @@ export const getFiltersData = createThunkAction('explore-dataset-filters/getFilt
     });
   });
 
-export const onClearFilters = createThunkAction('explore-dataset-filters/onClearFilters', () => (dispatch) => {
-  dispatch(getFiltersData());
-  dispatch(clearFilters());
-  dispatch(setInitialFilterStatus());
-  dispatch(updateURLParams());
-});
+export const onClearFilters = createThunkAction('explore-dataset-filters/onClearFilters', (updateURL = true) =>
+  (dispatch) => {
+    dispatch(getFiltersData());
+    dispatch(clearFilters());
+    dispatch(setInitialFilterStatus());
+    if (updateURL) {
+      dispatch(updateURLParams());
+    }
+  });
 
 export const onSetDatasetFilter = createThunkAction('explore-dataset-filters/onSetDatasetFilter', (filter = {}) =>
   (dispatch) => {

--- a/app/scripts/pages/explore/explore-dataset-filters/explore-dataset-filters-component.jsx
+++ b/app/scripts/pages/explore/explore-dataset-filters/explore-dataset-filters-component.jsx
@@ -13,7 +13,11 @@ import './explore-dataset-filters-styles.scss';
 
 class ExploreDatasetFilters extends PureComponent {
   componentWillUnmount() {
-    this.onClearFilters();
+    // We don't update the URL because if the user is
+    // navigating away from Explore, we don't want to be
+    // redirected right away to it (consequence of
+    // updating the URL after the navigation)
+    this.onClearFilters(false);
   }
 
   onChange(values = [], key) {
@@ -33,9 +37,10 @@ class ExploreDatasetFilters extends PureComponent {
   /**
    * Event handler executed when the user clicks the
    * "clear filters" button
+   * @param {boolean} [updateURL = true] Whether to update the URL or not
    */
-  onClearFilters() {
-    this.props.onClearFilters();
+  onClearFilters(updateURL = true) {
+    this.props.onClearFilters(updateURL);
     logEvent('Explore menu', 'Clear filter', 'Click');
   }
 


### PR DESCRIPTION
## Overview

This PR fixes a bug where the user wouldn't be able to leave the Explore page when clicking the "Learn more" link of a dataset after setting a filter. The user would be redirected right away to Explore once the navigation would be complete because the filters would be reset and they would trigger a URL update.

## Testing instructions

To test this fix, please follow these steps:
1. Go to the Explore page
2. Select the "All datasets" tab
3. Open the filters by clicking "Filter results"
4. Select the "Asia" geography
5. Click the information button of the first dataset
6. Click the "Learn more" link of the panel

You should correctly navigate to the detail of the dataset.

## Pivotal task

[Link](https://www.pivotaltracker.com/story/show/158217314)