### PR TITLE
Bug: unable to create a widget from a dataset page

### DIFF
--- a/app/scripts/pages/dataset/dataset-widget-editor/dataset-widget-editor-component.js
+++ b/app/scripts/pages/dataset/dataset-widget-editor/dataset-widget-editor-component.js
@@ -9,7 +9,7 @@ import { breakpoints } from 'helpers/responsive';
 import MediaQuery from 'react-responsive';
 
 // Widget editor
-import WidgetEditor, { VegaChart, getVegaTheme, Modal, SaveWidgetModal } from 'widget-editor';
+import WidgetEditor, { VegaChart, getVegaTheme, SaveWidgetModal } from 'widget-editor';
 
 // Modal
 // import Modal from 'components/Modal/Modal';
@@ -19,15 +19,20 @@ import WidgetEditor, { VegaChart, getVegaTheme, Modal, SaveWidgetModal } from 'w
 class DatasetWidgetEditor extends PureComponent {
   static propTypes = {
     dataset: PropTypes.object,
-    responsive: PropTypes.object
+    responsive: PropTypes.object,
+    toggleModal: PropTypes.func.isRequired
   }
 
-  state = {
-    showSaveModal: false
-  }
-
-  handleToggleSaveWidget = (bool) => {
-    this.setState({ showSaveModal: bool });
+  handleToggleSaveWidget = () => {
+    if (this.getWidgetConfig) {
+      this.props.toggleModal(true, {
+        children: SaveWidgetModal,
+        childrenProps: {
+          datasetId: this.props.dataset.id,
+          getWidgetConfig: this.getWidgetConfig
+        }
+      });
+    }
   }
 
   render() {
@@ -46,21 +51,9 @@ class DatasetWidgetEditor extends PureComponent {
             saveButtonMode="auto"
             embedButtonMode="auto"
             titleMode="auto"
-            provideWidgetConfig={(func) => { this.onGetWidgetConfig = func; }}
+            provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
             onSave={() => this.handleToggleSaveWidget(true)}
           />
-
-          <Modal
-            isOpen={this.state.showSaveModal}
-            className="-medium"
-            onRequestClose={() => this.handleToggleSaveWidget(false)}
-          >
-            <SaveWidgetModal
-              dataset={dataset.id}
-              getWidgetConfig={this.onGetWidgetConfig}
-              onRequestClose={() => this.handleToggleSaveWidget(false)}
-            />
-          </Modal>
         </MediaQuery>
 
         {defaultEditableWidget &&

--- a/app/scripts/pages/dataset/dataset-widget-editor/index.js
+++ b/app/scripts/pages/dataset/dataset-widget-editor/index.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { modalActions } from 'widget-editor';
 
 import DatasetWidgetEditorComponent from './dataset-widget-editor-component';
 
@@ -9,5 +10,7 @@ export default connect(
       fakeWidth: 1024
     }
   }),
-  null
+  dispatch => ({
+    toggleModal: (...params) => dispatch(modalActions.toggleModal(...params))
+  })
 )(DatasetWidgetEditorComponent);


### PR DESCRIPTION
This PR fixes an issue that prevented the user from being able to create a widget from a dataset.

## Testing instructions

1. Go to http://localhost:5000/dataset/Politcial-Boundaries-GADM-adminitrative-level-1-1490086842541?basemap=default&bbox&boundaries=false&filterQuery=&labels=none&lat=24.367113562651276&lng=-66.97265625000001&location=GLOBAL&minZoom=3&tab=all_datasets&water=none&zoom=3
2. Configure the widget-editor so it displays a chart
3. Click the "Save visualization button"

At this point, a modal should appear.

## Pivotal

[Pivotal task](https://www.pivotaltracker.com/story/show/159660563)