### PR TITLE
Fix NexGDDP and Loca

### DIFF
--- a/app/scripts/actions/locatool.js
+++ b/app/scripts/actions/locatool.js
@@ -319,7 +319,7 @@ export function setTempResolutionSelection(selection, changeUrl = true) {
 
     dispatch({
       type: LOCA_SET_RANGE2_SELECTION,
-      payload: undefined
+      payload: null
     });
 
     if (changeUrl) dispatch(updateUrl());
@@ -349,7 +349,7 @@ export function setRange1Selection(selection, changeUrl = true) {
     if (range2Selection && selection.value === range2Selection.value) {
       dispatch({
         type: LOCA_SET_RANGE2_SELECTION,
-        payload: undefined
+        payload: null
       });
     }
 

--- a/app/scripts/actions/nexgddptool.js
+++ b/app/scripts/actions/nexgddptool.js
@@ -319,7 +319,7 @@ export function setTempResolutionSelection(selection, changeUrl = true) {
 
     dispatch({
       type: NEXGDDP_SET_RANGE2_SELECTION,
-      payload: undefined
+      payload: null
     });
 
     if (changeUrl) dispatch(updateUrl());
@@ -349,7 +349,7 @@ export function setRange1Selection(selection, changeUrl = true) {
     if (range2Selection && selection.value === range2Selection.value) {
       dispatch({
         type: NEXGDDP_SET_RANGE2_SELECTION,
-        payload: undefined
+        payload: null
       });
     }
 

--- a/app/scripts/components/loca-tool/date-range-select/DateRangeSelect.jsx
+++ b/app/scripts/components/loca-tool/date-range-select/DateRangeSelect.jsx
@@ -34,13 +34,13 @@ class DateRangeSelect extends React.PureComponent {
           value={range1.selection}
           onChange={setRange1Selection}
           options={range1Options}
-          clearable={false}
         />
         <Select
           name="enddate"
           value={range2.selection}
           onChange={setRange2Selection}
           options={range2Options}
+          isClearable
         />
       </div>
     );

--- a/app/scripts/components/loca-tool/date-range-select/DateRangeSelect.jsx
+++ b/app/scripts/components/loca-tool/date-range-select/DateRangeSelect.jsx
@@ -23,7 +23,7 @@ class DateRangeSelect extends React.PureComponent {
 
     range2Options = range2Options.map(o => ({
       ...o,
-      disabled: range1.selection && o.value === range1.selection.value
+      isDisabled: range1.selection && o.value === range1.selection.value
     }));
 
     return (

--- a/app/scripts/components/loca-tool/date-range-select/style.scss
+++ b/app/scripts/components/loca-tool/date-range-select/style.scss
@@ -6,7 +6,7 @@
   position: relative;
 }
 
-.c-date-range-select > .Select {
+.c-date-range-select > div {
   width: 50%;
   min-width: 100px;
 
@@ -18,7 +18,7 @@
     left: -2px;
   }
 
-  .Select-control {
+  > div {
     border: 2px solid $border-color;
     border-radius: 0;
   }

--- a/app/scripts/components/loca-tool/scenario-select/style.scss
+++ b/app/scripts/components/loca-tool/scenario-select/style.scss
@@ -4,17 +4,13 @@
   position: relative;
   z-index: 1;
 
-  .Select {
+  > div {
     border: 0;
     border-radius: 0;
 
-    .Select-control {
+    > div {
       border: 2px solid $border-color;
       border-radius: 0;
-    }
-
-    .Select-menu-outer {
-      z-index: 10000;
     }
   }
 }

--- a/app/scripts/components/loca-tool/temp-resolution-select/style.scss
+++ b/app/scripts/components/loca-tool/temp-resolution-select/style.scss
@@ -4,17 +4,13 @@
   position: relative;
   z-index: 1;
 
-  .Select {
+  > div {
     border: 0;
     border-radius: 0;
 
-    .Select-control {
+    > div {
       border: 2px solid $border-color;
       border-radius: 0;
-    }
-
-    .Select-menu-outer {
-      z-index: 10000;
     }
   }
 }

--- a/app/scripts/components/nexgddp-tool/date-range-select/DateRangeSelect.jsx
+++ b/app/scripts/components/nexgddp-tool/date-range-select/DateRangeSelect.jsx
@@ -34,13 +34,13 @@ class DateRangeSelect extends React.PureComponent {
           value={range1.selection}
           onChange={setRange1Selection}
           options={range1Options}
-          clearable={false}
         />
         <Select
           name="enddate"
           value={range2.selection}
           onChange={setRange2Selection}
           options={range2Options}
+          isClearable
         />
       </div>
     );

--- a/app/scripts/components/nexgddp-tool/date-range-select/DateRangeSelect.jsx
+++ b/app/scripts/components/nexgddp-tool/date-range-select/DateRangeSelect.jsx
@@ -23,7 +23,7 @@ class DateRangeSelect extends React.PureComponent {
 
     range2Options = range2Options.map(o => ({
       ...o,
-      disabled: range1.selection && o.value === range1.selection.value
+      isDisabled: range1.selection && o.value === range1.selection.value
     }));
 
     return (

--- a/app/scripts/components/nexgddp-tool/date-range-select/style.scss
+++ b/app/scripts/components/nexgddp-tool/date-range-select/style.scss
@@ -6,7 +6,7 @@
   position: relative;
 }
 
-.c-date-range-select > .Select {
+.c-date-range-select > div {
   width: 50%;
   min-width: 100px;
 
@@ -18,7 +18,7 @@
     left: -2px;
   }
 
-  .Select-control {
+  > div {
     border: 2px solid $border-color;
     border-radius: 0;
   }

--- a/app/scripts/components/nexgddp-tool/scenario-select/style.scss
+++ b/app/scripts/components/nexgddp-tool/scenario-select/style.scss
@@ -4,17 +4,13 @@
   position: relative;
   z-index: 1;
 
-  .Select {
+  > div {
     border: 0;
     border-radius: 0;
 
-    .Select-control {
+    > div {
       border: 2px solid $border-color;
       border-radius: 0;
-    }
-
-    .Select-menu-outer {
-      z-index: 10000;
     }
   }
 }

--- a/app/scripts/components/nexgddp-tool/temp-resolution-select/style.scss
+++ b/app/scripts/components/nexgddp-tool/temp-resolution-select/style.scss
@@ -4,17 +4,13 @@
   position: relative;
   z-index: 1;
 
-  .Select {
+  > div {
     border: 0;
     border-radius: 0;
 
-    .Select-control {
+    > div {
       border: 2px solid $border-color;
       border-radius: 0;
-    }
-
-    .Select-menu-outer {
-      z-index: 10000;
     }
   }
 }

--- a/app/scripts/selectors/locatool.js
+++ b/app/scripts/selectors/locatool.js
@@ -84,9 +84,9 @@ export const getIndicatorId = createSelector(
   (dataset) => { // eslint-disable-line no-shadow
     const metadata = dataset && dataset.metadata.length ? dataset.metadata[0] : null;
     const indicatorId = metadata
-      && metadata.attributes.info
-      && metadata.attributes.info.loca
-      && metadata.attributes.info.loca.indicator_id;
+      && metadata.info
+      && metadata.info.loca
+      && metadata.info.loca.indicator_id;
     return indicatorId || null;
   }
 );
@@ -106,9 +106,9 @@ export const getTempResolution = createSelector(
   (dataset) => { // eslint-disable-line no-shadow
     const metadata = dataset && dataset.metadata.length ? dataset.metadata[0] : null;
     const tempResolution = metadata
-      && metadata.attributes.info
-      && metadata.attributes.info.loca
-      && metadata.attributes.info.loca.temp_resolution;
+      && metadata.info
+      && metadata.info.loca
+      && metadata.info.loca.temp_resolution;
     return tempResolution || null;
   }
 );

--- a/app/scripts/selectors/nexgddptool.js
+++ b/app/scripts/selectors/nexgddptool.js
@@ -84,9 +84,9 @@ export const getIndicatorId = createSelector(
   (dataset) => { // eslint-disable-line no-shadow
     const metadata = dataset && dataset.metadata.length ? dataset.metadata[0] : null;
     const indicatorId = metadata
-      && metadata.attributes.info
-      && metadata.attributes.info.nexgddp
-      && metadata.attributes.info.nexgddp.indicator_id;
+      && metadata.info
+      && metadata.info.nexgddp
+      && metadata.info.nexgddp.indicator_id;
     return indicatorId || null;
   }
 );
@@ -106,9 +106,9 @@ export const getTempResolution = createSelector(
   (dataset) => { // eslint-disable-line no-shadow
     const metadata = dataset && dataset.metadata.length ? dataset.metadata[0] : null;
     const tempResolution = metadata
-      && metadata.attributes.info
-      && metadata.attributes.info.nexgddp
-      && metadata.attributes.info.nexgddp.temp_resolution;
+      && metadata.info
+      && metadata.info.nexgddp
+      && metadata.info.nexgddp.temp_resolution;
     return tempResolution || null;
   }
 );


### PR DESCRIPTION
This PR addresses a couple of bugs which prevented the user from using the NexGDDP and Loca tools:
- they wouldn't load
- the date inputs would be broken

## Testing instructions

### The tools load
1. Go to http://0.0.0.0:5000/dataset/cum_pr_rcp45_decadal
2. Wait a few seconds

The tool should have loaded correctly.

### Second date range input can be emptied
1. Go to http://0.0.0.0:5000/dataset/cum_pr_rcp45_decadal
2. Select a value for the second date range input

There should be a cross icon in the second date range input and if the user clicks on it, it gets emptied.

### Second date range input prevents user from selecting same value in the first one
1. Go to http://0.0.0.0:5000/dataset/cum_pr_rcp45_decadal
2. Open the second date range input

The value of the first date range should be disabled in the second one.

### First date range input resets second one if same value
1. Go to http://0.0.0.0:5000/dataset/cum_pr_rcp45_decadal
2. Select a value for the second date range input
3. Select the same value for the first date range input

The second input should have reset because the user is not allowed to select twice the same range.

## Pivotal

Not tracked.