### PR TITLE
Bug: scope the styles of Explore's map legend

### DIFF
--- a/app/styles/components/_explore-legend.scss
+++ b/app/styles/components/_explore-legend.scss
@@ -1,33 +1,35 @@
-.wri_api__c-legend-map {
-  position: absolute;
-  right: 20px;
-  top: 20px;
-  border: 0;
+.c-explore-map {
+  .wri_api__c-legend-map {
+    position: absolute;
+    right: 20px;
+    top: 20px;
+    border: 0;
 
-  ul, ul > li {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .wri_api__c-legend-item {
-
-  }
-
-  .wri_api__c-legend-handler {
-    > svg {
-      fill: rgba($base-font-color, .4)
+    ul, ul > li {
+      list-style: none;
+      margin: 0;
+      padding: 0;
     }
-  }
 
-  .wri_api__c-legend-item-types {
-    margin-top: 10px;
-  }
+    .wri_api__c-legend-item {
 
-  .wri_api__toggle-legend {
-    top: 100%;
-    bottom: auto;
-    tranform: rotate(180deg);
+    }
+
+    .wri_api__c-legend-handler {
+      > svg {
+        fill: rgba($base-font-color, .4)
+      }
+    }
+
+    .wri_api__c-legend-item-types {
+      margin-top: 10px;
+    }
+
+    .wri_api__toggle-legend {
+      top: 100%;
+      bottom: auto;
+      tranform: rotate(180deg);
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where the styles of Explore's map legend would apply to the legend of the widget-editor.

## Testing instructions
1. Go to http://0.0.0.0:5000/dataset/Global-Reservoir-and-Dam-GRanD
2. Select "Map" in the widget-editor

The legend should be correctly placed above the map's credits. Note though that because of another bug, the legend actually doesn't display anything.

## Pivotal

[Task (only first part)](https://www.pivotaltracker.com/story/show/159739060)