### PR TITLE
Bug: widget-editor's legend not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "webpack-dev-middleware": "1.12.2",
     "webpack-merge": "4.1.0",
     "whatwg-fetch": "2.0.3",
-    "widget-editor": "1.3.5",
+    "widget-editor": "1.3.6",
     "wri-api-components": "^2.0.16",
     "wri-json-api-serializer": "^1.0.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,10 +479,6 @@ auto-changelog@^1.8.0:
     parse-github-url "^1.0.1"
     semver "^5.1.0"
 
-autobind-decorator@^1.3.4:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-1.4.3.tgz#4c96ffa77b10622ede24f110f5dbbf56691417d1"
-
 autobind-decorator@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.1.0.tgz#4451240dbfeff46361c506575a63ed40f0e5bc68"
@@ -7129,13 +7125,6 @@ react-input-autosize@^2.0.1, react-input-autosize@^2.1.2, react-input-autosize@^
   dependencies:
     prop-types "^15.5.8"
 
-react-input-range@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-input-range/-/react-input-range-1.3.0.tgz#f96d001631ab817417f1e26d8f9f9684b4827f59"
-  dependencies:
-    autobind-decorator "^1.3.4"
-    prop-types "^15.5.8"
-
 react-leaflet-control@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/react-leaflet-control/-/react-leaflet-control-1.4.1.tgz#5da234621682d9c50657b65af042398512bda0fb"
@@ -9668,9 +9657,9 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-widget-editor@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.3.5.tgz#8cf189f36ffb7f3f7e8e9d9160128c69a2a9640c"
+widget-editor@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.3.6.tgz#dc6894d23505f8b58254e3329d568a84aa4efcbc"
   dependencies:
     autobind-decorator "^2.1.0"
     babel-runtime "^6.26.0"
@@ -9693,7 +9682,7 @@ widget-editor@1.3.5:
     react-tether "^0.6.0"
     toastr "^2.1.2"
     vega-tooltip "^0.5.1"
-    wri-api-components "2.0.0"
+    wri-api-components "2.0.17"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -9739,15 +9728,19 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-wri-api-components@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.0.0.tgz#d5b67ea948a7ee9f086a829416760aacdc77fc78"
+wri-api-components@2.0.17:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.0.17.tgz#4033ccc382df6faf432cd52f8b0d5b91578dae03"
   dependencies:
-    prop-types "^15.6.1"
+    layer-manager "^1.0.4"
+    prop-types "^15.6.2"
+    rc-slider "^8.6.1"
     rc-tooltip "3.7.0"
     react-css-modules "^4.7.1"
-    react-input-range "1.3.0"
+    react-lib "^0.1.3"
     react-sortable-hoc "^0.6.8"
+    react-vega "^4.0.2"
+    vega-lib "^4.2.0"
     wri-json-api-serializer "^1.0.1"
 
 wri-api-components@^2.0.16:


### PR DESCRIPTION
This PR fixes an issue where the legend of the [widget-editor](https://github.com/resource-watch/widget-editor) wouldn't work properly.

## Testing instructions
1. Go to localhost:5000/dataset/Global-Reservoir-and-Dam-GRanD
2. Select the "Map" visualisation in the widget-editor
3. Click the toggle button of the legend

You should be able to see the content of the legend.

## Pivotal
[Task (second part)](https://www.pivotaltracker.com/story/show/159739060)