### PR TITLE
Bug: unable to create a widget from the Explore's map

### DIFF
--- a/app/scripts/components/Modal/CreateEmbedWidget.jsx
+++ b/app/scripts/components/Modal/CreateEmbedWidget.jsx
@@ -50,7 +50,7 @@ class CreateEmbedWidget extends React.Component {
       widgetConfig
     };
 
-    WidgetService.saveUserWidget(widget, dataset, getConfig().userToken)
+    WidgetService.saveUserWidget(dataset, getConfig().userToken, widget)
       .then((res) => {
         if (!links.length) return null;
 


### PR DESCRIPTION
This PR fixes an issue where the user would be unable to create a widget from the Explore map.

## Testing instructions
1. Log in
2. Go to http://localhost:5000/explore?activeDatasets=eadf93a6-58e7-4482-89d6-c9832d270a87%7C1%7Ctrue%7C0&basemap=default&bbox&boundaries=false&filterQuery=&labels=none&lat=24.44714958973082&lng=-66.97265625000001&location=GLOBAL&minZoom=3&tab=core_datasets&water=none&zoom=3
3. Click the share button of the map
4. Select the "Widget" tab in the modal
5. Give the widget a title and click "Create"

You shouldn't see any error in the modal or the console.

## Pivotal
Not tracked.