### PR TITLE
Bug: user can navigate away from Explore embed

### DIFF
--- a/app/scripts/pages/explore/explore-embed-component.jsx
+++ b/app/scripts/pages/explore/explore-embed-component.jsx
@@ -63,7 +63,7 @@ class ExplorePage extends PureComponent {
             </div>
           )}
 
-          <DatasetInfo />
+          <DatasetInfo embed={embed} />
         </div>
 
         {/* Map */}


### PR DESCRIPTION
This PR fixes a bug where the user can navigate away from the main visualisation of an Explore embed.

## Testing instructions
1. Go to http://localhost:5000/embed/explore/?activeDatasets=eadf93a6-58e7-4482-89d6-c9832d270a87%7C1%7Ctrue%7C0&basemap=default&bbox&boundaries=false&filterQuery=&labels=dark&lat=24.44714958973082&lng=-66.97265625000001&location=GLOBAL&minZoom=3&tab=core_datasets&water=none&zoom=3
2. Click the info button of the legend
3. Click "Learn more" in the sidebar

A new tab should open with the details of the dataset (instead of in the current tab).

## Pivotal
Part of [this task](https://www.pivotaltracker.com/story/show/159172219).