### PR TITLE
Display the author of the dashboards

### DIFF
--- a/app/scripts/components/Dashboards/index.jsx
+++ b/app/scripts/components/Dashboards/index.jsx
@@ -51,7 +51,7 @@ class DashboardsPage extends React.Component {
           <p>
             {item.summary}
           </p>
-          { !item.partner && item.author && item.author.logo && (
+          { !item.partner && item.author && item.author.logo && item.author.logo !== '/logos/original/missing.png' && (
             <a
               href={item.author.url}
               target="_blank"

--- a/app/scripts/components/Dashboards/index.jsx
+++ b/app/scripts/components/Dashboards/index.jsx
@@ -51,7 +51,21 @@ class DashboardsPage extends React.Component {
           <p>
             {item.summary}
           </p>
-          {item.partner &&
+          { !item.partner && item.author && item.author.logo && (
+            <a
+              href={item.author.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={config.assetsUrl + item.author.logo}
+                className="logo"
+                alt={item.author.name}
+              />
+            </a>
+          )}
+
+          {item.partner && (
             <a
               href={item.partner.url}
               target="_blank"
@@ -64,10 +78,19 @@ class DashboardsPage extends React.Component {
                 alt={item.partner.name}
               />
             </a>
-          }
-          {item.attribution &&
-            <span className="attribution">{item.attribution}</span>
-          }
+          )}
+
+          {!item.attribution && item.author && item.author.name && (
+            <span className="attribution">
+              {item.author.name}
+            </span>
+          )}
+
+          {item.attribution && (
+            <span className="attribution">
+              {item.attribution}
+            </span>
+          ) }
         </Card>
       </div>
     ));


### PR DESCRIPTION
This PR displays the author of the dashboards.

<p align="center">
<img width="470" alt="Dashboard card with a logo and the name of the author" src="https://user-images.githubusercontent.com/6073968/44204040-05652780-a149-11e8-8e50-28dc24f8ebed.png">
</p>


## Testing instructions
1. Add the param `published=all` to [this query](https://github.com/resource-watch/prep-app/blob/2865db5421a2270bb20e88e465e61ed7b4d74a45/app/scripts/actions/dashboards.js#L14)
2. Go to http://localhost:5000/dashboards

The first dashboard, Test Clément - partner, contains a logo and the name of the author.

## Pivotal
Part of [this task](https://www.pivotaltracker.com/story/show/158256199).