### PR TITLE
Bug: users unable to login because of the tooltip

### DIFF
--- a/app/scripts/modules/user/index.js
+++ b/app/scripts/modules/user/index.js
@@ -23,6 +23,13 @@ const mapStateToProps = state => ({
 });
 
 class UserContainer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleHover = this.handleHover.bind(this);
+    this.handleLogOut = this.handleLogOut.bind(this);
+  }
+
   componentDidMount() {
     const { data } = this.props;
     if (!isEmpty(data)) return;
@@ -71,8 +78,8 @@ class UserContainer extends Component {
   render() {
     return createElement(UserComponent, {
       ...this.props,
-      handleHover: this.handleHover.bind(this),
-      handleLogOut: this.handleLogOut.bind(this)
+      handleHover: this.handleHover,
+      handleLogOut: this.handleLogOut
     });
   }
 }


### PR DESCRIPTION
This PR fixes an issue where some users reported being unable to login because the tooltip wouldn't open.

## Testing instructions
1. Go to http://localhost:5000/ and log out
2. Open the developer tools and simulate an iPad in landscape mode
3. Reload the page

You should be able to open the login tooltip by hovering the account icon and by clicking on one of the providers.

## Pivotal
[Task](https://www.pivotaltracker.com/story/show/159120484)