### PR TITLE
Bug: NexGDDP widgets might fail to load

### DIFF
--- a/app/scripts/pages/nexgddp-embed/nexgddp-embed-component.jsx
+++ b/app/scripts/pages/nexgddp-embed/nexgddp-embed-component.jsx
@@ -23,8 +23,8 @@ class NexGDDPEmbedPage extends PureComponent {
   render() {
     const { dataset, embed } = this.props;
 
-    const title = dataset.metadata && dataset.metadata.length && dataset.metadata[0].attributes.name
-      ? dataset.metadata[0].attributes.name
+    const title = dataset.metadata && dataset.metadata.length && dataset.metadata[0].name
+      ? dataset.metadata[0].name
       : dataset.name;
 
     return (

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "history": "^2.0.0",
     "html-webpack-plugin": "2.29.0",
     "image-webpack-loader": "3.3.0",
-    "jsonapi-serializer": "3.5.3",
     "layer-manager": "^1.0.16",
     "leaflet": "1.2.0",
     "lodash": "4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,10 +4548,6 @@ indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
-inflected@^1.1.6:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/inflected/-/inflected-1.1.7.tgz#c393df6e28472d0d77b3082ec3aa2091f4bc96f9"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -5116,13 +5112,6 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonapi-serializer@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/jsonapi-serializer/-/jsonapi-serializer-3.5.3.tgz#0800af04a72befc7ae71be5673272632315fbdab"
-  dependencies:
-    inflected "^1.1.6"
-    lodash "^4.16.3"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -5448,7 +5437,7 @@ lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.0.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.16.3, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
This PR fixes an issue where some NexGDDP widgets might fail to load because the project used two different serializer that would return different results.

## Testing instructions
1. Open http://localhost:5000/embed/nexgddp/xpr_rcp45_decadal?zoom=6&lat=23.059516273509317&lng=78.4423828125&mapMode=side-by-side&graphMode=timeseries&scenario=rcp45&tempResolution=decadal&range1=2011-01-01T00%3A00%3A00.000Z&range2=2041-01-01T00%3A00%3A00.000Z&labels=light&boundaries=true&render=map

The layers should load correctly.

## Pivotal
Part of [this task](https://www.pivotaltracker.com/story/show/159829264).