### PR TITLE
Bug: unable to hide sidebar in Explore embeds

### DIFF
--- a/app/styles/components/_info-sidebar.scss
+++ b/app/styles/components/_info-sidebar.scss
@@ -4,6 +4,7 @@
   left: $sidebar-width;
   height: calc(100% - #{$header-height-short});
   width: 100%;
+  max-width: calc(100% - 50px); // For the embeds
   background-color: $base-bg-color;
   z-index: 2;
   transform: translateX(-($sidebar-width * 2));


### PR DESCRIPTION
This PR fixes an issue where the user would be unable to hide the sidebar of the Explore embeds once opened because the close button would be outside the viewport.

On this image, you can see the fix lets the user close the sidebar (right):
<p align="center">
<img width="1280" alt="Side-by-side comparison of the embeds with and without the fix. On the right, the button to close the sidebar is visible." src="https://user-images.githubusercontent.com/6073968/44259638-fdb98780-a209-11e8-880c-43f923d301d6.png">
</p>

## Testing instructions
1. Open http://localhost:3000/embed/explore/?activeDatasets=d597c392-086d-4e4f-b33b-4d8f520bb547%7C1%7Ctrue%7C2&basemap=light&bbox&boundaries=true&filterQuery=irrigat&labels=dark&lat=23.926013645952843&lng=77.96997204422954&location=IND&minZoom=3&tab=all_datasets&water=none&zoom=6
2. Click the info button of the legend

You should be able to close the sidebar.

## Pivotal
Part of [this task](https://www.pivotaltracker.com/story/show/159829264).